### PR TITLE
DM-16536: Migrate all metrics from ap.verify.measurements

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2017-2018 University of Washington
+Copyright 2017-2019 University of Washington

--- a/doc/lsst.ap.association/index.rst
+++ b/doc/lsst.ap.association/index.rst
@@ -28,11 +28,29 @@ You can find Jira issues for this module under the `ap_association <https://jira
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 
+.. _lsst.ap.association-command-line-taskref:
+
+Task reference
+==============
+
+.. _lsst.ap.association-tasks:
+
+Tasks
+-----
+
+.. lsst-tasks::
+   :root: lsst.ap.association
+   :toctree: tasks
+
 .. _lsst.ap.association-pyapi:
 
 Python API reference
 ====================
 
 .. automodapi:: lsst.ap.association
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.ap.association.metrics
    :no-main-docstr:
    :no-inheritance-diagram:

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask.rst
@@ -1,0 +1,50 @@
+.. lsst-task-topic:: lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask
+
+###################################
+FractionUpdatedDiaObjectsMetricTask
+###################################
+
+``FractionUpdatedDiaObjectsMetricTask`` computes the fraction of DIAObjects that were updated when processing data through source association (as the ``ap_association.fracUpdatedDiaObjects`` metric).
+It requires task metadata as input.
+While the task can operate at image-level or coarser granularity, the current algorithm may double-count objects and should not be run on multiple visits.
+
+.. _lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask-summary:
+
+Processing summary
+==================
+
+``FractionUpdatedDiaObjectsMetricTask`` reads ``AssociationTask`` statistics from task metadata associated with one or more processed images.
+It uses these statistics to compute the fraction of potentially updatable DIAObjects that were updated with new sources when processing those images.
+
+.. _lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.metadataMetricTask.MetadataMetricConfig.metadata`
+    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
+    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``FractionUpdatedDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask.rst
@@ -1,0 +1,49 @@
+.. lsst-task-topic:: lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask
+
+#############################
+NumberNewDiaObjectsMetricTask
+#############################
+
+``NumberNewDiaObjectsMetricTask`` computes the number of DIAObjects created when processing data through source association (as the ``ap_association.numNewDiaObjects`` metric).
+It requires task metadata as input, and can operate at image-level or coarser granularity.
+
+.. _lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask-summary:
+
+Processing summary
+==================
+
+``NumberNewDiaObjectsMetricTask`` reads ``AssociationTask`` statistics from task metadata associated with one or more processed images.
+It uses these statistics to count the number of new DIAObjects added when processing those images.
+
+.. _lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.metadataMetricTask.MetadataMetricConfig.metadata`
+    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
+    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``NumberNewDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask.rst
@@ -1,0 +1,50 @@
+.. lsst-task-topic:: lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask
+
+######################################
+NumberUnassociatedDiaObjectsMetricTask
+######################################
+
+``NumberUnassociatedDiaObjectsMetricTask`` computes the number of DIAObjects that are *not* updated when processing data through source association (as the ``ap_association.numUnassociatedDiaObjects`` metric).
+It requires task metadata as input.
+While the task can operate at image-level or coarser granularity, the current algorithm may double-count objects and should not be run on multiple visits.
+
+.. _lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask-summary:
+
+Processing summary
+==================
+
+``NumberUnassociatedDiaObjectsMetricTask`` reads ``AssociationTask`` statistics from task metadata associated with one or more processed images.
+It uses these statistics to count the number of unassociated DIAObjects when processing those images.
+
+.. _lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.metadataMetricTask.MetadataMetricConfig.metadata`
+    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
+    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``NumberUnassociatedDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask.rst
@@ -1,0 +1,49 @@
+.. lsst-task-topic:: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
+
+#####################################
+TotalUnassociatedDiaObjectsMetricTask
+#####################################
+
+``TotalUnassociatedDiaObjectsMetricTask`` computes the number of DIAObjects that have only a single source (as the ``ap_association.totalUnassociatedDiaObjects`` metric).
+It requires a prompt products database as input, and is meaningful only at dataset-level granularity.
+
+.. _lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask-summary:
+
+Processing summary
+==================
+
+``TotalUnassociatedDiaObjectsMetricTask`` queries the database (through `~lsst.dax.ppdb.Ppdb`) for the number of DIAObjects with exactly one source.
+
+.. _lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.ppdbMetricTask.PpdbMetricConfig.dbInfo`
+    The Butler dataset from which the database connection can be initialized.
+    The type must match the input required by the :lsst-config-field:`~lsst.verify.tasks.ppdbMetricTask.PpdbMetricConfig.dbLoader` subtask (default: the top-level science task's config).
+    If the input is a config, its name **must** be explicitly configured when running ``TotalUnassociatedDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
+
+.. _lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask

--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -1,0 +1,202 @@
+# This file is part of ap_association.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+__all__ = ["NumberNewDiaObjectsMetricTask",
+           "NumberUnassociatedDiaObjectsMetricTask",
+           "FractionUpdatedDiaObjectsMetricTask",
+           ]
+
+
+import astropy.units as u
+
+from lsst.verify import Measurement
+from lsst.verify.gen2tasks import register
+from lsst.verify.tasks import MetadataMetricTask, MetricComputationError
+
+
+@register("numNewDiaObjects")
+class NumberNewDiaObjectsMetricTask(MetadataMetricTask):
+    """Task that computes the number of DIASources that create new DIAObjects
+    in an image, visit, etc..
+    """
+    _DefaultName = "numNewDiaObjects"
+
+    def makeMeasurement(self, values):
+        """Compute the number of new DIAObjects.
+
+        Parameters
+        ----------
+        values : sequence [`dict` [`str`, `int` or `None`]]
+            A list where each element corresponds to a metadata object passed
+            to `run`. Each `dict` has the following key:
+
+            ``"newObjects"``
+                The number of new objects created for this image (`int`
+                or `None`). May be `None` if the image was not successfully
+                associated.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The total number of new objects.
+        """
+        nNew = 0
+        associated = False
+        for value in values:
+            if value["newObjects"] is not None:
+                try:
+                    nNew += value["newObjects"]
+                except TypeError as e:
+                    raise MetricComputationError("Corrupted value of numNewDiaObjects") from e
+                associated = True
+
+        if associated:
+            return Measurement(self.getOutputMetricName(self.config),
+                               nNew * u.count)
+        else:
+            self.log.info("Nothing to do: no association results found.")
+            return None
+
+    @classmethod
+    def getInputMetadataKeys(cls, config):
+        return {"newObjects": ".numNewDiaObjects"}
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return "ap_association.numNewDiaObjects"
+
+
+@register("numUnassociatedDiaObjects")
+class NumberUnassociatedDiaObjectsMetricTask(MetadataMetricTask):
+    """Task that computes the number of previously-known DIAObjects that do
+    not have detected DIASources in an image, visit, etc..
+    """
+    _DefaultName = "numUnassociatedDiaObjects"
+
+    def makeMeasurement(self, values):
+        """Compute the number of non-updated DIAObjects.
+
+        Parameters
+        ----------
+        values : sequence [`dict` [`str`, `int` or `None`]]
+            A list where each element corresponds to a metadata object passed
+            to `run`. Each `dict` has the following key:
+
+            ``"unassociatedObjects"``
+                The number of DIAObjects not associated with a DiaSource in
+                this image (`int` or `None`). May be `None` if the image was
+                not successfully associated.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The total number of unassociated objects.
+        """
+        nNew = 0
+        associated = False
+        for value in values:
+            if value["unassociatedObjects"] is not None:
+                try:
+                    nNew += value["unassociatedObjects"]
+                except TypeError as e:
+                    raise MetricComputationError("Corrupted value of numUnassociatedDiaObjects") from e
+                associated = True
+
+        if associated:
+            return Measurement(self.getOutputMetricName(self.config),
+                               nNew * u.count)
+        else:
+            self.log.info("Nothing to do: no association results found.")
+            return None
+
+    @classmethod
+    def getInputMetadataKeys(cls, config):
+        return {"unassociatedObjects": ".numUnassociatedDiaObjects"}
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return "ap_association.numUnassociatedDiaObjects"
+
+
+@register("fracUpdatedDiaObjects")
+class FractionUpdatedDiaObjectsMetricTask(MetadataMetricTask):
+    """Task that computes the fraction of previously created DIAObjects that
+    have a new association in this image, visit, etc..
+    """
+    _DefaultName = "fracUpdatedDiaObjects"
+
+    def makeMeasurement(self, values):
+        """Compute the number of non-updated DIAObjects.
+
+        Parameters
+        ----------
+        values : sequence [`dict` [`str`, `int` or `None`]]
+            A list where each element corresponds to a metadata object passed
+            to `run`. Each `dict` has the following keys:
+
+            ``"updatedObjects"``
+                The number of DIAObjects updated for this image (`int` or
+                `None`). May be `None` if the image was not
+                successfully associated.
+            ``"unassociatedObjects"``
+                The number of DIAObjects not associated with a DiaSource in
+                this image (`int` or `None`). May be `None` if the image was
+                not successfully associated.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The total number of unassociated objects.
+        """
+        nUpdated = 0
+        nUnassociated = 0
+        associated = False
+        for value in values:
+            if value["updatedObjects"] is not None \
+                    and value["unassociatedObjects"] is not None:
+                try:
+                    nUpdated += value["updatedObjects"]
+                    nUnassociated += value["unassociatedObjects"]
+                except TypeError as e:
+                    raise MetricComputationError("Corrupted value of numUpdatedDiaObjects "
+                                                 "or numUnassociatedDiaObjects") from e
+                associated = True
+
+        if associated:
+            if nUpdated <= 0 and nUnassociated <= 0:
+                raise MetricComputationError("No pre-existing DIAObjects; can't compute updated fraction.")
+            else:
+                fraction = nUpdated / (nUpdated + nUnassociated)
+                return Measurement(self.getOutputMetricName(self.config),
+                                   fraction * u.dimensionless_unscaled)
+        else:
+            self.log.info("Nothing to do: no association results found.")
+            return None
+
+    @classmethod
+    def getInputMetadataKeys(cls, config):
+        return {"updatedObjects": ".numUpdatedDiaObjects",
+                "unassociatedObjects": ".numUnassociatedDiaObjects"}
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return "ap_association.fracUpdatedDiaObjects"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,301 @@
+# This file is part of ap_association.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+
+import lsst.utils.tests
+from lsst.daf.base import PropertySet
+from lsst.verify import Name
+from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
+from lsst.verify.tasks import MetricComputationError
+from lsst.verify.tasks.testUtils import MetadataMetricTestCase
+
+from lsst.ap.association.metrics import \
+    NumberNewDiaObjectsMetricTask, \
+    NumberUnassociatedDiaObjectsMetricTask, \
+    FractionUpdatedDiaObjectsMetricTask
+
+
+def _makeAssociationMetadata(numUpdated=27, numNew=4, numUnassociated=15):
+    metadata = PropertySet()
+    metadata.add("association.numUpdatedDiaObjects", numUpdated)
+    metadata.add("association.numNewDiaObjects", numNew)
+    metadata.add("association.numUnassociatedDiaObjects", numUnassociated)
+    return metadata
+
+
+class TestNewDiaObjects(MetadataMetricTestCase):
+
+    @classmethod
+    def makeTask(cls):
+        return NumberNewDiaObjectsMetricTask()
+
+    def testValid(self):
+        metadata = _makeAssociationMetadata()
+        result = self.task.run([metadata])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ap_association.numNewDiaObjects"))
+        self.assertEqual(meas.quantity, metadata.getAsDouble("association.numNewDiaObjects") * u.count)
+
+    def testNoNew(self):
+        metadata = _makeAssociationMetadata(numNew=0)
+        result = self.task.run([metadata])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ap_association.numNewDiaObjects"))
+        self.assertEqual(meas.quantity, 0.0 * u.count)
+
+    def testMissingData(self):
+        result = self.task.run([None])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testNoDataExpected(self):
+        result = self.task.run([])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testAssociationFailed(self):
+        result = self.task.run([PropertySet()])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testBadlyTypedKeys(self):
+        metadata = _makeAssociationMetadata()
+        metadata.set("association.numNewDiaObjects", "Ultimate Answer")
+
+        with self.assertRaises(MetricComputationError):
+            self.task.run([metadata])
+
+    def testGetInputDatasetTypes(self):
+        config = self.taskClass.ConfigClass()
+        config.metadata.name = "test_metadata"
+        types = self.taskClass.getInputDatasetTypes(config)
+        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
+        self.assertSetEqual(set(types.keys()), {"metadata"})
+        self.assertEqual(types["metadata"], "test_metadata")
+
+    def testFineGrainedMetric(self):
+        metadata = _makeAssociationMetadata()
+        inputData = {"metadata": [metadata]}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
+        measDirect = self.task.run([metadata]).measurement
+        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
+
+    def testCoarseGrainedMetric(self):
+        metadata = _makeAssociationMetadata()
+        nCcds = 3
+        inputData = {"metadata": [metadata] * nCcds}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": x} for x in range(nCcds)]}
+        outputDataId = {"measurement": {"visit": 42}}
+        measDirect = self.task.run([metadata]).measurement
+        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measMany.quantity, nCcds * measDirect.quantity)
+
+
+class TestUnassociatedDiaObjects(MetadataMetricTestCase):
+
+    @classmethod
+    def makeTask(cls):
+        return NumberUnassociatedDiaObjectsMetricTask()
+
+    def testValid(self):
+        metadata = _makeAssociationMetadata()
+        result = self.task.run([metadata])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ap_association.numUnassociatedDiaObjects"))
+        self.assertEqual(meas.quantity,
+                         metadata.getAsDouble("association.numUnassociatedDiaObjects") * u.count)
+
+    def testAllUpdated(self):
+        metadata = _makeAssociationMetadata(numUnassociated=0)
+        result = self.task.run([metadata])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ap_association.numUnassociatedDiaObjects"))
+        self.assertEqual(meas.quantity, 0.0 * u.count)
+
+    def testMissingData(self):
+        result = self.task.run([None])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testNoDataExpected(self):
+        result = self.task.run([])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testAssociationFailed(self):
+        result = self.task.run([PropertySet()])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testBadlyTypedKeys(self):
+        metadata = _makeAssociationMetadata()
+        metadata.set("association.numUnassociatedDiaObjects", "Ultimate Answer")
+
+        with self.assertRaises(MetricComputationError):
+            self.task.run([metadata])
+
+    def testGetInputDatasetTypes(self):
+        config = self.taskClass.ConfigClass()
+        config.metadata.name = "test_metadata"
+        types = self.taskClass.getInputDatasetTypes(config)
+        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
+        self.assertSetEqual(set(types.keys()), {"metadata"})
+        self.assertEqual(types["metadata"], "test_metadata")
+
+    def testFineGrainedMetric(self):
+        metadata = _makeAssociationMetadata()
+        inputData = {"metadata": [metadata]}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
+        measDirect = self.task.run([metadata]).measurement
+        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
+
+    def testCoarseGrainedMetric(self):
+        metadata = _makeAssociationMetadata()
+        nCcds = 3
+        inputData = {"metadata": [metadata] * nCcds}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": x} for x in range(nCcds)]}
+        outputDataId = {"measurement": {"visit": 42}}
+        measDirect = self.task.run([metadata]).measurement
+        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measMany.quantity, nCcds * measDirect.quantity)
+
+
+class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
+
+    @classmethod
+    def makeTask(cls):
+        return FractionUpdatedDiaObjectsMetricTask()
+
+    def testValid(self):
+        metadata = _makeAssociationMetadata()
+        result = self.task.run([metadata])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ap_association.fracUpdatedDiaObjects"))
+        nUpdated = metadata.getAsDouble("association.numUpdatedDiaObjects")
+        nTotal = metadata.getAsDouble("association.numUnassociatedDiaObjects") + nUpdated
+        self.assertEqual(meas.quantity, nUpdated / nTotal * u.dimensionless_unscaled)
+
+    def testNoUpdated(self):
+        metadata = _makeAssociationMetadata(numUpdated=0)
+        result = self.task.run([metadata])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ap_association.fracUpdatedDiaObjects"))
+        self.assertEqual(meas.quantity, 0.0 * u.dimensionless_unscaled)
+
+    def testAllUpdated(self):
+        metadata = _makeAssociationMetadata(numUnassociated=0)
+        result = self.task.run([metadata])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ap_association.fracUpdatedDiaObjects"))
+        self.assertEqual(meas.quantity, 1.0 * u.dimensionless_unscaled)
+
+    def testNoObjects(self):
+        metadata = _makeAssociationMetadata(numUpdated=0, numUnassociated=0)
+        with self.assertRaises(MetricComputationError):
+            self.task.run([metadata])
+
+    def testMissingData(self):
+        result = self.task.run([None])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testNoDataExpected(self):
+        result = self.task.run([])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testAssociationFailed(self):
+        result = self.task.run([PropertySet()])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testBadlyTypedKeys(self):
+        metadata = _makeAssociationMetadata()
+        metadata.set("association.numUnassociatedDiaObjects", "Ultimate Answer")
+
+        with self.assertRaises(MetricComputationError):
+            self.task.run([metadata])
+
+    def testGetInputDatasetTypes(self):
+        config = self.taskClass.ConfigClass()
+        config.metadata.name = "test_metadata"
+        types = self.taskClass.getInputDatasetTypes(config)
+        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
+        self.assertSetEqual(set(types.keys()), {"metadata"})
+        self.assertEqual(types["metadata"], "test_metadata")
+
+    def testFineGrainedMetric(self):
+        metadata = _makeAssociationMetadata()
+        inputData = {"metadata": [metadata]}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
+        measDirect = self.task.run([metadata]).measurement
+        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
+
+    def testCoarseGrainedMetric(self):
+        metadata = _makeAssociationMetadata()
+        nCcds = 3
+        inputData = {"metadata": [metadata] * nCcds}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": x} for x in range(nCcds)]}
+        outputDataId = {"measurement": {"visit": 42}}
+        measDirect = self.task.run([metadata]).measurement
+        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measMany.quantity, measDirect.quantity)
+
+
+# Hack around unittest's hacky test setup system
+del MetricTaskTestCase
+del MetadataMetricTestCase
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/ups/ap_association.table
+++ b/ups/ap_association.table
@@ -10,6 +10,7 @@ setupRequired(meas_algorithms)
 setupRequired(pex_config)
 setupRequired(pipe_base)
 setupRequired(dax_ppdb)
+setupRequired(verify)
 
 setupRequired(numpy)
 setupRequired(scipy)


### PR DESCRIPTION
This PR defines `MetricTask` subclasses for the `ap_association.numNewDiaObjects`, `ap_association.numUnassociatedDiaObjects`, `ap_association.fracUpdatedDiaObjects`, and `ap_association.totalUnassociatedDiaObjects` metrics, which were previously implemented as functions in `ap_verify` (see lsst/ap_verify#63). This change requires that `ap_association` depend on `lsst.verify`.

Design note: most of the complexity of the task code comes from `MetricTask` instances not being allowed to assume a particular granularity for their metric. This, in turn, is partly because of Gen 2 (i.e., `MetricsControllerTask`) limitations, but largely because it's not yet known who will be responsible for metrics aggregation.