### PR TITLE
DM-20974: Remove aggregation support/requirement from MetricTask

### DIFF
--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -46,9 +46,9 @@ class NumberNewDiaObjectsMetricTask(MetadataMetricTask):
 
         Parameters
         ----------
-        values : sequence [`dict` [`str`, `int` or `None`]]
-            A list where each element corresponds to a metadata object passed
-            to `run`. Each `dict` has the following key:
+        values : `dict` [`str`, `int` or `None`]
+            A `dict` representation of the metadata. Each `dict` has the
+            following key:
 
             ``"newObjects"``
                 The number of new objects created for this image (`int`
@@ -60,19 +60,14 @@ class NumberNewDiaObjectsMetricTask(MetadataMetricTask):
         measurement : `lsst.verify.Measurement` or `None`
             The total number of new objects.
         """
-        nNew = 0
-        associated = False
-        for value in values:
-            if value["newObjects"] is not None:
-                try:
-                    nNew += value["newObjects"]
-                except TypeError as e:
-                    raise MetricComputationError("Corrupted value of numNewDiaObjects") from e
-                associated = True
-
-        if associated:
-            return Measurement(self.getOutputMetricName(self.config),
-                               nNew * u.count)
+        if values["newObjects"] is not None:
+            try:
+                nNew = int(values["newObjects"])
+            except (ValueError, TypeError) as e:
+                raise MetricComputationError("Corrupted value of numNewDiaObjects") from e
+            else:
+                return Measurement(self.getOutputMetricName(self.config),
+                                   nNew * u.count)
         else:
             self.log.info("Nothing to do: no association results found.")
             return None
@@ -98,9 +93,9 @@ class NumberUnassociatedDiaObjectsMetricTask(MetadataMetricTask):
 
         Parameters
         ----------
-        values : sequence [`dict` [`str`, `int` or `None`]]
-            A list where each element corresponds to a metadata object passed
-            to `run`. Each `dict` has the following key:
+        values : `dict` [`str`, `int` or `None`]
+            A `dict` representation of the metadata. Each `dict` has the
+            following key:
 
             ``"unassociatedObjects"``
                 The number of DIAObjects not associated with a DiaSource in
@@ -112,19 +107,14 @@ class NumberUnassociatedDiaObjectsMetricTask(MetadataMetricTask):
         measurement : `lsst.verify.Measurement` or `None`
             The total number of unassociated objects.
         """
-        nNew = 0
-        associated = False
-        for value in values:
-            if value["unassociatedObjects"] is not None:
-                try:
-                    nNew += value["unassociatedObjects"]
-                except TypeError as e:
-                    raise MetricComputationError("Corrupted value of numUnassociatedDiaObjects") from e
-                associated = True
-
-        if associated:
-            return Measurement(self.getOutputMetricName(self.config),
-                               nNew * u.count)
+        if values["unassociatedObjects"] is not None:
+            try:
+                nNew = int(values["unassociatedObjects"])
+            except (ValueError, TypeError) as e:
+                raise MetricComputationError("Corrupted value of numUnassociatedDiaObjects") from e
+            else:
+                return Measurement(self.getOutputMetricName(self.config),
+                                   nNew * u.count)
         else:
             self.log.info("Nothing to do: no association results found.")
             return None
@@ -150,9 +140,9 @@ class FractionUpdatedDiaObjectsMetricTask(MetadataMetricTask):
 
         Parameters
         ----------
-        values : sequence [`dict` [`str`, `int` or `None`]]
-            A list where each element corresponds to a metadata object passed
-            to `run`. Each `dict` has the following keys:
+        values : `dict` [`str`, `int` or `None`]
+            A `dict` representation of the metadata. Each `dict` has the
+            following keys:
 
             ``"updatedObjects"``
                 The number of DIAObjects updated for this image (`int` or
@@ -168,27 +158,22 @@ class FractionUpdatedDiaObjectsMetricTask(MetadataMetricTask):
         measurement : `lsst.verify.Measurement` or `None`
             The total number of unassociated objects.
         """
-        nUpdated = 0
-        nUnassociated = 0
-        associated = False
-        for value in values:
-            if value["updatedObjects"] is not None \
-                    and value["unassociatedObjects"] is not None:
-                try:
-                    nUpdated += value["updatedObjects"]
-                    nUnassociated += value["unassociatedObjects"]
-                except TypeError as e:
-                    raise MetricComputationError("Corrupted value of numUpdatedDiaObjects "
-                                                 "or numUnassociatedDiaObjects") from e
-                associated = True
-
-        if associated:
-            if nUpdated <= 0 and nUnassociated <= 0:
-                raise MetricComputationError("No pre-existing DIAObjects; can't compute updated fraction.")
+        if values["updatedObjects"] is not None \
+                and values["unassociatedObjects"] is not None:
+            try:
+                nUpdated = int(values["updatedObjects"])
+                nUnassociated = int(values["unassociatedObjects"])
+            except (ValueError, TypeError) as e:
+                raise MetricComputationError("Corrupted value of numUpdatedDiaObjects "
+                                             "or numUnassociatedDiaObjects") from e
             else:
-                fraction = nUpdated / (nUpdated + nUnassociated)
-                return Measurement(self.getOutputMetricName(self.config),
-                                   fraction * u.dimensionless_unscaled)
+                if nUpdated <= 0 and nUnassociated <= 0:
+                    raise MetricComputationError(
+                        "No pre-existing DIAObjects; can't compute updated fraction.")
+                else:
+                    fraction = nUpdated / (nUpdated + nUnassociated)
+                    return Measurement(self.getOutputMetricName(self.config),
+                                       fraction * u.dimensionless_unscaled)
         else:
             self.log.info("Nothing to do: no association results found.")
             return None

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -58,7 +58,7 @@ class TestNewDiaObjects(MetadataMetricTestCase):
 
     def testValid(self):
         metadata = _makeAssociationMetadata()
-        result = self.task.run([metadata])
+        result = self.task.run(metadata)
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numNewDiaObjects"))
@@ -66,24 +66,19 @@ class TestNewDiaObjects(MetadataMetricTestCase):
 
     def testNoNew(self):
         metadata = _makeAssociationMetadata(numNew=0)
-        result = self.task.run([metadata])
+        result = self.task.run(metadata)
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numNewDiaObjects"))
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
     def testMissingData(self):
-        result = self.task.run([None])
-        meas = result.measurement
-        self.assertIsNone(meas)
-
-    def testNoDataExpected(self):
-        result = self.task.run([])
+        result = self.task.run(None)
         meas = result.measurement
         self.assertIsNone(meas)
 
     def testAssociationFailed(self):
-        result = self.task.run([PropertySet()])
+        result = self.task.run(PropertySet())
         meas = result.measurement
         self.assertIsNone(meas)
 
@@ -92,7 +87,7 @@ class TestNewDiaObjects(MetadataMetricTestCase):
         metadata.set("association.numNewDiaObjects", "Ultimate Answer")
 
         with self.assertRaises(MetricComputationError):
-            self.task.run([metadata])
+            self.task.run(metadata)
 
     def testGetInputDatasetTypes(self):
         config = self.taskClass.ConfigClass()
@@ -104,24 +99,13 @@ class TestNewDiaObjects(MetadataMetricTestCase):
 
     def testFineGrainedMetric(self):
         metadata = _makeAssociationMetadata()
-        inputData = {"metadata": [metadata]}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        inputData = {"metadata": metadata}
+        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
         outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run([metadata]).measurement
+        measDirect = self.task.run(metadata).measurement
         measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
 
         assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
-
-    def testCoarseGrainedMetric(self):
-        metadata = _makeAssociationMetadata()
-        nCcds = 3
-        inputData = {"metadata": [metadata] * nCcds}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": x} for x in range(nCcds)]}
-        outputDataId = {"measurement": {"visit": 42}}
-        measDirect = self.task.run([metadata]).measurement
-        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
-
-        assert_quantity_allclose(measMany.quantity, nCcds * measDirect.quantity)
 
 
 class TestUnassociatedDiaObjects(MetadataMetricTestCase):
@@ -132,7 +116,7 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
 
     def testValid(self):
         metadata = _makeAssociationMetadata()
-        result = self.task.run([metadata])
+        result = self.task.run(metadata)
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numUnassociatedDiaObjects"))
@@ -141,24 +125,19 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
 
     def testAllUpdated(self):
         metadata = _makeAssociationMetadata(numUnassociated=0)
-        result = self.task.run([metadata])
+        result = self.task.run(metadata)
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numUnassociatedDiaObjects"))
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
     def testMissingData(self):
-        result = self.task.run([None])
-        meas = result.measurement
-        self.assertIsNone(meas)
-
-    def testNoDataExpected(self):
-        result = self.task.run([])
+        result = self.task.run(None)
         meas = result.measurement
         self.assertIsNone(meas)
 
     def testAssociationFailed(self):
-        result = self.task.run([PropertySet()])
+        result = self.task.run(PropertySet())
         meas = result.measurement
         self.assertIsNone(meas)
 
@@ -167,7 +146,7 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
         metadata.set("association.numUnassociatedDiaObjects", "Ultimate Answer")
 
         with self.assertRaises(MetricComputationError):
-            self.task.run([metadata])
+            self.task.run(metadata)
 
     def testGetInputDatasetTypes(self):
         config = self.taskClass.ConfigClass()
@@ -179,24 +158,13 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
 
     def testFineGrainedMetric(self):
         metadata = _makeAssociationMetadata()
-        inputData = {"metadata": [metadata]}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        inputData = {"metadata": metadata}
+        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
         outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run([metadata]).measurement
+        measDirect = self.task.run(metadata).measurement
         measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
 
         assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
-
-    def testCoarseGrainedMetric(self):
-        metadata = _makeAssociationMetadata()
-        nCcds = 3
-        inputData = {"metadata": [metadata] * nCcds}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": x} for x in range(nCcds)]}
-        outputDataId = {"measurement": {"visit": 42}}
-        measDirect = self.task.run([metadata]).measurement
-        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
-
-        assert_quantity_allclose(measMany.quantity, nCcds * measDirect.quantity)
 
 
 class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
@@ -207,7 +175,7 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
     def testValid(self):
         metadata = _makeAssociationMetadata()
-        result = self.task.run([metadata])
+        result = self.task.run(metadata)
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.fracUpdatedDiaObjects"))
@@ -217,7 +185,7 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
     def testNoUpdated(self):
         metadata = _makeAssociationMetadata(numUpdated=0)
-        result = self.task.run([metadata])
+        result = self.task.run(metadata)
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.fracUpdatedDiaObjects"))
@@ -225,7 +193,7 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
     def testAllUpdated(self):
         metadata = _makeAssociationMetadata(numUnassociated=0)
-        result = self.task.run([metadata])
+        result = self.task.run(metadata)
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.fracUpdatedDiaObjects"))
@@ -234,20 +202,15 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
     def testNoObjects(self):
         metadata = _makeAssociationMetadata(numUpdated=0, numUnassociated=0)
         with self.assertRaises(MetricComputationError):
-            self.task.run([metadata])
+            self.task.run(metadata)
 
     def testMissingData(self):
-        result = self.task.run([None])
-        meas = result.measurement
-        self.assertIsNone(meas)
-
-    def testNoDataExpected(self):
-        result = self.task.run([])
+        result = self.task.run(None)
         meas = result.measurement
         self.assertIsNone(meas)
 
     def testAssociationFailed(self):
-        result = self.task.run([PropertySet()])
+        result = self.task.run(PropertySet())
         meas = result.measurement
         self.assertIsNone(meas)
 
@@ -256,7 +219,7 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
         metadata.set("association.numUnassociatedDiaObjects", "Ultimate Answer")
 
         with self.assertRaises(MetricComputationError):
-            self.task.run([metadata])
+            self.task.run(metadata)
 
     def testGetInputDatasetTypes(self):
         config = self.taskClass.ConfigClass()
@@ -268,24 +231,13 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
     def testFineGrainedMetric(self):
         metadata = _makeAssociationMetadata()
-        inputData = {"metadata": [metadata]}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        inputData = {"metadata": metadata}
+        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
         outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run([metadata]).measurement
+        measDirect = self.task.run(metadata).measurement
         measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
 
         assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
-
-    def testCoarseGrainedMetric(self):
-        metadata = _makeAssociationMetadata()
-        nCcds = 3
-        inputData = {"metadata": [metadata] * nCcds}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": x} for x in range(nCcds)]}
-        outputDataId = {"measurement": {"visit": 42}}
-        measDirect = self.task.run([metadata]).measurement
-        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
-
-        assert_quantity_allclose(measMany.quantity, measDirect.quantity)
 
 
 class TestTotalUnassociatedObjects(PpdbMetricTestCase):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -329,7 +329,7 @@ class TestTotalUnassociatedObjects(PpdbMetricTestCase):
         # Do the patch here to avoid passing extra arguments to superclass tests
 
     def testValid(self):
-        result = self.task.adaptArgsAndRun({"dbInfo": [{"test_value": 42}]},
+        result = self.task.adaptArgsAndRun({"dbInfo": {"test_value": 42}},
                                            {"dbInfo": {}},
                                            {"measurement": {}})
         meas = result.measurement
@@ -338,7 +338,7 @@ class TestTotalUnassociatedObjects(PpdbMetricTestCase):
         self.assertEqual(meas.quantity, 42 * u.count)
 
     def testAllAssociated(self):
-        result = self.task.adaptArgsAndRun({"dbInfo": [{"test_value": 0}]},
+        result = self.task.adaptArgsAndRun({"dbInfo": {"test_value": 0}},
                                            {"dbInfo": {}},
                                            {"measurement": {}})
         meas = result.measurement


### PR DESCRIPTION
This PR changes metadata-based metrics to take single inputs, following support for non-aggregating metrics in lsst/verify#54.