### PR TITLE
DM-21098: Isolate outdated Gen 3 methods in gen2tasks

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -88,14 +88,6 @@ class TestNewDiaObjects(MetadataMetricTestCase):
         with self.assertRaises(MetricComputationError):
             self.task.run(metadata)
 
-    def testGetInputDatasetTypes(self):
-        config = self.taskClass.ConfigClass()
-        config.connections.taskName = "test"
-        types = self.taskClass.getInputDatasetTypes(config)
-        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
-        self.assertSetEqual(set(types.keys()), {"metadata"})
-        self.assertEqual(types["metadata"], "test_metadata")
-
 
 class TestUnassociatedDiaObjects(MetadataMetricTestCase):
 
@@ -136,14 +128,6 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
 
         with self.assertRaises(MetricComputationError):
             self.task.run(metadata)
-
-    def testGetInputDatasetTypes(self):
-        config = self.taskClass.ConfigClass()
-        config.connections.taskName = "test"
-        types = self.taskClass.getInputDatasetTypes(config)
-        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
-        self.assertSetEqual(set(types.keys()), {"metadata"})
-        self.assertEqual(types["metadata"], "test_metadata")
 
 
 class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
@@ -199,14 +183,6 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
         with self.assertRaises(MetricComputationError):
             self.task.run(metadata)
-
-    def testGetInputDatasetTypes(self):
-        config = self.taskClass.ConfigClass()
-        config.connections.taskName = "test"
-        types = self.taskClass.getInputDatasetTypes(config)
-        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
-        self.assertSetEqual(set(types.keys()), {"metadata"})
-        self.assertEqual(types["metadata"], "test_metadata")
 
 
 class TestTotalUnassociatedObjects(PpdbMetricTestCase):
@@ -271,14 +247,6 @@ class TestTotalUnassociatedObjects(PpdbMetricTestCase):
     def testFineGrainedMetric(self):
         with self.assertRaises(ValueError):
             self.task.run(self.makeDbInfo(), outputDataId={"visit": 42})
-
-    def testGetInputDatasetTypes(self):
-        config = self.taskClass.ConfigClass()
-        config.connections.dbInfo = "absolutely anything"
-        types = self.taskClass.getInputDatasetTypes(config)
-        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
-        self.assertSetEqual(set(types.keys()), {"dbInfo"})
-        self.assertEqual(types["dbInfo"], "absolutely anything")
 
 
 # Hack around unittest's hacky test setup system

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -23,7 +23,6 @@ import unittest
 import unittest.mock
 
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
 
 import lsst.utils.tests
 from lsst.pex.config import Config
@@ -97,16 +96,6 @@ class TestNewDiaObjects(MetadataMetricTestCase):
         self.assertSetEqual(set(types.keys()), {"metadata"})
         self.assertEqual(types["metadata"], "test_metadata")
 
-    def testFineGrainedMetric(self):
-        metadata = _makeAssociationMetadata()
-        inputData = {"metadata": metadata}
-        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
-        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run(metadata).measurement
-        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
-
-        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
-
 
 class TestUnassociatedDiaObjects(MetadataMetricTestCase):
 
@@ -155,16 +144,6 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
         # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
         self.assertSetEqual(set(types.keys()), {"metadata"})
         self.assertEqual(types["metadata"], "test_metadata")
-
-    def testFineGrainedMetric(self):
-        metadata = _makeAssociationMetadata()
-        inputData = {"metadata": metadata}
-        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
-        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run(metadata).measurement
-        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
-
-        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
 
 
 class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
@@ -228,16 +207,6 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
         # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
         self.assertSetEqual(set(types.keys()), {"metadata"})
         self.assertEqual(types["metadata"], "test_metadata")
-
-    def testFineGrainedMetric(self):
-        metadata = _makeAssociationMetadata()
-        inputData = {"metadata": metadata}
-        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
-        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run(metadata).measurement
-        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
-
-        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
 
 
 class TestTotalUnassociatedObjects(PpdbMetricTestCase):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -221,13 +221,9 @@ class TestTotalUnassociatedObjects(PpdbMetricTestCase):
         instantiated.
         """
         ppdb = unittest.mock.Mock(Ppdb)
-        try:
-            test_value = dummy_dbInfo["test_value"]
-            ppdb.countUnassociatedObjects = unittest.mock.MagicMock(
-                return_value=test_value)
-        except TypeError:
-            ppdb.countUnassociatedObjects = unittest.mock.MagicMock(
-                return_value=42)
+        test_value = dummy_dbInfo["test_value"]
+        ppdb.countUnassociatedObjects = unittest.mock.MagicMock(
+            return_value=test_value)
         return ppdb
 
     @classmethod
@@ -244,6 +240,10 @@ class TestTotalUnassociatedObjects(PpdbMetricTestCase):
         config = TotalUnassociatedDiaObjectsMetricTask.ConfigClass()
         config.dbLoader.retarget(SimpleDbLoader)
         return TotalUnassociatedDiaObjectsMetricTask(config=config)
+
+    @classmethod
+    def makeDbInfo(cls):
+        return {"test_value": "whatever"}
 
     def setUp(self):
         super().setUp()
@@ -270,7 +270,7 @@ class TestTotalUnassociatedObjects(PpdbMetricTestCase):
 
     def testFineGrainedMetric(self):
         with self.assertRaises(ValueError):
-            self.task.run("DB source", outputDataId={"visit": 42})
+            self.task.run(self.makeDbInfo(), outputDataId={"visit": 42})
 
     def testGetInputDatasetTypes(self):
         config = self.taskClass.ConfigClass()


### PR DESCRIPTION
This PR removes tests of `adaptArgsAndRun` and `getInputDatasetTypes` from the metric test suite. These tests would have been broken by the Gen 3 migration, and testing their functionality is redundant because these methods should not be overloaded (following the changes in lsst/verify#55).

The PR also simplifies some of the code for testing `TestTotalUnassociatedObjects`, removing some special-casing. It must be merged together with lsst/verify#55, which makes supporting changes to the generic test code.