### PR TITLE
DM-20902: FractionUpdatedDiaObjectsMetricTask should expect 0 DIAObjects

### DIFF
--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -171,8 +171,7 @@ class FractionUpdatedDiaObjectsMetricTask(MetadataMetricTask):
                                              "or numUnassociatedDiaObjects") from e
             else:
                 if nUpdated <= 0 and nUnassociated <= 0:
-                    raise MetricComputationError(
-                        "No pre-existing DIAObjects; can't compute updated fraction.")
+                    return None  # No pre-existing DIAObjects; no fraction to compute
                 else:
                     fraction = nUpdated / (nUpdated + nUnassociated)
                     return Measurement(self.getOutputMetricName(self.config),

--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -138,6 +138,9 @@ class FractionUpdatedDiaObjectsMetricTask(MetadataMetricTask):
     def makeMeasurement(self, values):
         """Compute the number of non-updated DIAObjects.
 
+        AssociationTask reports each pre-existing DIAObject as either updated
+        (associated with a new DIASource) or unassociated.
+
         Parameters
         ----------
         values : `dict` [`str`, `int` or `None`]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -164,8 +164,10 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
     def testNoObjects(self):
         metadata = _makeAssociationMetadata(numUpdated=0, numUnassociated=0)
-        with self.assertRaises(MetricComputationError):
-            self.task.run(metadata)
+        result = self.task.run(metadata)
+        meas = result.measurement
+
+        self.assertIsNone(meas)
 
     def testMissingData(self):
         result = self.task.run(None)


### PR DESCRIPTION
This PR changes the behavior of `FractionUpdatedDiaObjectsMetricTask` when there are no pre-existing objects. This case is now treated as "not applicable" rather than as a computation failure in the metric.