### PR TITLE
DM-21877: Create "marker" Butler dataset for PPDB

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -225,7 +225,6 @@ class TestTotalUnassociatedObjects(ApdbMetricTestCase):
 
     def setUp(self):
         super().setUp()
-        # Do the patch here to avoid passing extra arguments to superclass tests
 
     def testValid(self):
         result = self.task.run([{"test_value": 42}])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -228,14 +228,14 @@ class TestTotalUnassociatedObjects(ApdbMetricTestCase):
         # Do the patch here to avoid passing extra arguments to superclass tests
 
     def testValid(self):
-        result = self.task.run({"test_value": 42})
+        result = self.task.run([{"test_value": 42}])
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.totalUnassociatedDiaObjects"))
         self.assertEqual(meas.quantity, 42 * u.count)
 
     def testAllAssociated(self):
-        result = self.task.run({"test_value": 0})
+        result = self.task.run([{"test_value": 0}])
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.totalUnassociatedDiaObjects"))
@@ -248,7 +248,7 @@ class TestTotalUnassociatedObjects(ApdbMetricTestCase):
 
     def testFineGrainedMetric(self):
         with self.assertRaises(ValueError):
-            self.task.run(self.makeDbInfo(), outputDataId={"visit": 42})
+            self.task.run([self.makeDbInfo()], outputDataId={"visit": 42})
 
 
 # Hack around unittest's hacky test setup system


### PR DESCRIPTION
The PR updates the unit tests for `TotalUnassociatedDiaObjectsMetricTask` to provide multiple inputs, as required following lsst/verify#57.