### PR TITLE
DM-22478: Lightly restructure ap_association tasks and create new DiaObject/DiaSource pre-loading task.

### DIFF
--- a/python/lsst/ap/association/__init__.py
+++ b/python/lsst/ap/association/__init__.py
@@ -26,3 +26,4 @@ from .mapApData import *
 from .afwUtils import *
 from .diaCalculation import *
 from .diaCalculationPlugins import *
+from .loadDiaCatalogs import *

--- a/python/lsst/ap/association/diaCalculation.py
+++ b/python/lsst/ap/association/diaCalculation.py
@@ -418,7 +418,10 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
                                    diaSources=diaSourcesGB,
                                    filterDiaSources=filterDiaSourcesGB,
                                    filterName=filterName)
-
+        # Need to store the newly updated diaObjects directly as the editing
+        # a view into diaObjectsToUpdate does not update the values of
+        # diaObjectCat.
+        diaObjectCat.loc[updatedDiaObjectIds, :] = diaObjectsToUpdate
         return lsst.pipe.base.Struct(
             diaObjectCat=diaObjectCat,
             updatedDiaObjects=diaObjectsToUpdate)

--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -129,7 +129,7 @@ class DiaForcedSourceTask(pipeBase.Task):
         self.makeSubtask("forcedMeasurement",
                          refSchema=afwTable.SourceTable.makeMinimalSchema())
 
-    def run(self, dia_objects, expIdBits, exposure, diffim, apdb=None):
+    def run(self, dia_objects, expIdBits, exposure, diffim, apdb):
         """Measure forced sources on the direct and different images,
         calibrate, and store them in the Apdb.
 
@@ -144,6 +144,8 @@ class DiaForcedSourceTask(pipeBase.Task):
             Direct image exposure.
         diffim : `lsst.afw.image.Exposure`
             Difference image.
+        apdb : `lsst.dax.apdb.Apdb`
+            Connection to the association database.
 
         Returns
         -------
@@ -177,6 +179,7 @@ class DiaForcedSourceTask(pipeBase.Task):
                                                           directForcedSources,
                                                           diffim,
                                                           exposure)
+        apdb.storeDiaForcedSources(output_forced_sources)
 
         return output_forced_sources
 

--- a/python/lsst/ap/association/loadDiaCatalogs.py
+++ b/python/lsst/ap/association/loadDiaCatalogs.py
@@ -1,0 +1,217 @@
+# This file is part of ap_association.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Task for pre-loading DiaSources and DiaObjects within ap_pipe.
+"""
+import pandas as pd
+
+import lsst.geom as geom
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.sphgeom as sphgeom
+
+__all__ = ("LoadDiaCatalogsTask", "LoadDiaCatalogsConfig")
+
+
+class LoadDiaCatalogsConfig(pexConfig.Config):
+    """Config class for LoadDiaCatalogsConfig.
+    """
+    htmLevel = pexConfig.RangeField(
+        dtype=int,
+        doc="Level of the HTM pixelization.",
+        default=20,
+        min=1,
+    )
+    htmMaxRanges = pexConfig.RangeField(
+        dtype=int,
+        doc="Maximum number of HTM (min, max) ranges to return.",
+        default=128,
+        min=2,
+    )
+    pixelMargin = pexConfig.RangeField(
+        doc="Padding to add to 4 all edges of the bounding box (pixels)",
+        dtype=int,
+        default=300,
+        min=0,
+    )
+    loadDiaSourcesByPixelId = pexConfig.Field(
+        doc="Load DiaSources by their HTM pixelId instead of by their "
+            "associated diaObjectId",
+        dtype=bool,
+        default=False,
+    )
+
+
+class LoadDiaCatalogsTask(pipeBase.Task):
+    """Retrieve DiaObjects and associated DiaSources from the Apdb given an
+    input exposure.
+    """
+    ConfigClass = LoadDiaCatalogsConfig
+    _DefaultName = "loadDiaCatalogs"
+
+    def __init__(self, **kwargs):
+        pipeBase.Task.__init__(self, **kwargs)
+        self.pixelator = sphgeom.HtmPixelization(self.config.htmLevel)
+
+    @pipeBase.timeMethod
+    def run(self, exposure, apdb):
+        """Preload all DiaObjects and DiaSources from the Apdb given the
+        current exposure.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.Exposure`
+            An exposure with a bounding box.
+        apdb : `lsst.dax.apdb.Apdb`
+            AP database connection object.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            Results struct with components.
+
+            - ``diaObjects`` : Complete set of DiaObjects covering the input
+              exposure padded by ``pixelMargin``. DataFrame is indexed by
+              the ``diaObjectId`` column. (`pandas.DataFrame`)
+            - ``diaSources`` : Complete set of DiaSources covering the input
+              exposure padded by ``pixelMargin``. DataFrame is indexed by
+              ``diaObjectId``, ``filterName``, ``diaSourceId`` columns.
+              (`pandas.DataFrame`)
+        """
+        pixelRanges = self._getPixelRanges(exposure)
+
+        diaObjects = self.loadDiaObjects(pixelRanges, apdb)
+
+        dateTime = exposure.getInfo().getVisitInfo().getDate().toPython()
+
+        diaSources = self.loadDiaSources(diaObjects,
+                                         dateTime,
+                                         pixelRanges,
+                                         apdb)
+
+        return pipeBase.Struct(
+            diaObjects=diaObjects,
+            diaSources=diaSources)
+
+    @pipeBase.timeMethod
+    def loadDiaObjects(self, pixelRanges, apdb):
+        """Load DiaObjects from the Apdb based on their HTM location.
+
+        Parameters
+        ----------
+        pixelRanges : `tuple` [`int`]
+            Ranges of pixel values that cover region of interest.
+        apdb : `lsst.dax.apdb.Apdb`
+            Database connection object to load from.
+
+        Returns
+        -------
+        diaObjects : `pandas.DataFrame`
+            DiaObjects loaded from the Apdb that are within the area defined
+            by ``pixelRanges``.
+        """
+        if len(pixelRanges) == 0:
+            # If no area is specified return an empty DataFrame with the
+            # the column used for indexing later in AssociationTask.
+            diaObjects = pd.DataFrame(columns=["diaObjectId"])
+        else:
+            diaObjects = apdb.getDiaObjects(pixelRanges, return_pandas=True)
+        diaObjects.set_index("diaObjectId", drop=False, inplace=True)
+        return diaObjects
+
+    @pipeBase.timeMethod
+    def loadDiaSources(self, diaObjects, pixelRanges, dateTime, apdb):
+        """Load DiaSources from the Apdb based on their diaObjectId or
+        pixelId location.
+
+        Variable used to load sources is set in config.
+
+        Parameters
+        ----------
+        diaObjects : `pandas.DataFrame`
+            DiaObjects loaded from the Apdb that are within the area defined
+            by ``pixelRanges``.
+        pixelRanges : `list` of `tuples`
+            Ranges of pixelIds that cover region of interest.
+        dataTime : `datetime.datetime`
+            Time of the current visit
+        apdb : `lsst.dax.apdb.Apdb`
+            Database connection object to load from.
+
+        Returns
+        -------
+        DiaSources : `pandas.DataFrame`
+            DiaSources loaded from the Apdb that are within the area defined
+            by ``pixelRange`` and associated with ``diaObjects``.
+        """
+        if self.config.loadDiaSourcesByPixelId:
+            if len(pixelRanges) == 0:
+                # If no area is specified return an empty DataFrame with the
+                # the column used for indexing later in AssociationTask.
+                diaSources = pd.DataFrame(columns=["diaObjectId",
+                                                   "filterName",
+                                                   "diaSourceId"])
+            else:
+                diaSources = apdb.getDiaSourcesInRegion(pixelRanges,
+                                                        dateTime,
+                                                        return_pandas=True)
+        else:
+            if len(diaObjects) == 0:
+                # If no diaObjects are available return an empty DataFrame with
+                # the the column used for indexing later in AssociationTask.
+                diaSources = pd.DataFrame(columns=["diaObjectId",
+                                                   "filterName",
+                                                   "diaSourceId"])
+            else:
+                diaSources = apdb.getDiaSources(
+                    diaObjects.loc[:, "diaObjectId"],
+                    dateTime,
+                    return_pandas=True)
+
+        diaSources.set_index(["diaObjectId", "filterName", "diaSourceId"],
+                             drop=False,
+                             inplace=True)
+        return diaSources
+
+    @pipeBase.timeMethod
+    def _getPixelRanges(self, exposure):
+        """Calculate covering HTM pixels for the current exposure.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.Exposure`
+            Exposure object with calibrated WCS.
+
+        Returns
+        -------
+        htmRanges : `list` of `tuples`
+            A list of tuples containing `int` values.
+        """
+        bbox = geom.Box2D(exposure.getBBox())
+        bbox.grow(self.config.pixelMargin)
+        wcs = exposure.getWcs()
+
+        region = sphgeom.ConvexPolygon([wcs.pixelToSky(pp).getVector()
+                                        for pp in bbox.getCorners()])
+
+        indices = self.pixelator.envelope(region, self.config.htmMaxRanges)
+
+        return indices.ranges()

--- a/tests/test_diaForcedSource.py
+++ b/tests/test_diaForcedSource.py
@@ -21,6 +21,7 @@
 
 import numpy as np
 import unittest
+import unittest.mock
 
 from lsst.afw.cameraGeom.testUtils import DetectorWrapper
 import lsst.afw.geom as afwGeom
@@ -28,6 +29,7 @@ import lsst.afw.image as afwImage
 import lsst.afw.image.utils as afwImageUtils
 import lsst.afw.table as afwTable
 import lsst.daf.base as dafBase
+from lsst.dax.apdb import Apdb
 import lsst.meas.algorithms as measAlg
 from lsst.ap.association import \
     DiaForcedSourceTask, \
@@ -164,10 +166,11 @@ class TestDiaForcedSource(unittest.TestCase):
         """
 
         test_objects = self._convert_to_pandas(self.testDiaObjects)
+        apdb = unittest.mock.Mock(Apdb)
 
         dfs = DiaForcedSourceTask()
         dia_forced_sources = dfs.run(
-            test_objects, self.expIdBits, self.exposure, self.diffim)
+            test_objects, self.expIdBits, self.exposure, self.diffim, apdb)
 
         direct_values = [199854.48417094944, 160097.40719241602,
                          82299.17897267535, 27148.604434624354,

--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -1,0 +1,360 @@
+# This file is part of ap_association.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import numpy as np
+import pandas as pd
+import tempfile
+import unittest
+
+from lsst.afw.cameraGeom.testUtils import DetectorWrapper
+import lsst.afw.geom as afwGeom
+import lsst.afw.image as afwImage
+import lsst.afw.image.utils as afwImageUtils
+from lsst.ap.association import (LoadDiaCatalogsTask,
+                                 LoadDiaCatalogsConfig,
+                                 make_dia_source_schema,
+                                 make_dia_object_schema)
+import lsst.daf.base as dafBase
+from lsst.dax.apdb import Apdb, ApdbConfig
+import lsst.geom as geom
+import lsst.sphgeom as sphgeom
+from lsst.utils import getPackageDir
+import lsst.utils.tests
+
+
+def _data_file_name(basename, module_name):
+    """Return path name of a data file.
+
+    Parameters
+    ----------
+    basename : `str`
+        Name of the file to add to the path string.
+    module_name : `str`
+        Name of lsst stack package environment variable.
+
+    Returns
+    -------
+    data_file_path : `str`
+       Full path of the file to load from the "data" directory in a given
+       repository.
+    """
+    return os.path.join(getPackageDir(module_name), "data", basename)
+
+
+def makeExposure(flipX=False, flipY=False):
+    """Create an exposure and flip the x or y (or both) coordinates.
+
+    Returns bounding boxes that are right or left handed around the bounding
+    polygon.
+
+    Parameters
+    ----------
+    flipX : `bool`
+        Flip the x coordinate in the WCS.
+    flipY : `bool`
+        Flip the y coordinate in the WCS.
+
+    Returns
+    -------
+    exposure : `lsst.afw.image.Exposure`
+        Exposure with a valid bounding box and wcs.
+    """
+    metadata = dafBase.PropertySet()
+
+    metadata.set("SIMPLE", "T")
+    metadata.set("BITPIX", -32)
+    metadata.set("NAXIS", 2)
+    metadata.set("NAXIS1", 1024)
+    metadata.set("NAXIS2", 1153)
+    metadata.set("RADECSYS", 'FK5')
+    metadata.set("EQUINOX", 2000.)
+
+    metadata.setDouble("CRVAL1", 215.604025685476)
+    metadata.setDouble("CRVAL2", 53.1595451514076)
+    metadata.setDouble("CRPIX1", 1109.99981456774)
+    metadata.setDouble("CRPIX2", 560.018167811613)
+    metadata.set("CTYPE1", 'RA---SIN')
+    metadata.set("CTYPE2", 'DEC--SIN')
+
+    xFlip = 1
+    if flipX:
+        xFlip = -1
+    yFlip = 1
+    if flipY:
+        yFlip = -1
+    metadata.setDouble("CD1_1", xFlip * 5.10808596133527E-05)
+    metadata.setDouble("CD1_2", yFlip * 1.85579539217196E-07)
+    metadata.setDouble("CD2_2", yFlip * -5.10281493481982E-05)
+    metadata.setDouble("CD2_1", xFlip * -8.27440751733828E-07)
+
+    wcs = afwGeom.makeSkyWcs(metadata)
+    exposure = afwImage.makeExposure(
+        afwImage.makeMaskedImageFromArrays(np.ones((1024, 1153))), wcs)
+    detector = DetectorWrapper(id=23, bbox=exposure.getBBox()).detector
+    visit = afwImage.VisitInfo(
+        exposureId=1234,
+        exposureTime=200.,
+        date=dafBase.DateTime("2014-05-13T17:00:00.000000000",
+                              dafBase.DateTime.Timescale.TAI))
+    exposure.setDetector(detector)
+    exposure.getInfo().setVisitInfo(visit)
+    exposure.setFilter(afwImage.Filter('g'))
+
+    return exposure
+
+
+def makeDiaObjects(nObjects, exposure, pixelator):
+    """Make a test set of DiaObjects.
+
+    Parameters
+    ----------
+    nObjects : `int`
+        Number of objects to create.
+    exposure : `lsst.afw.image.Exposure`
+        Exposure to create objects over.
+    pixelator : `lsst.sphgeom.HtmPixelization`
+        Object to compute spatial indicies from.
+
+    Returns
+    -------
+    diaObjects : `pandas.DataFrame`
+        DiaObjects generated across the exposure.
+    """
+    bbox = geom.Box2D(exposure.getBBox())
+    rand_x = np.random.uniform(bbox.getMinX(), bbox.getMaxX(), size=nObjects)
+    rand_y = np.random.uniform(bbox.getMinY(), bbox.getMaxY(), size=nObjects)
+
+    midPointTaiMJD = exposure.getInfo().getVisitInfo().getDate().get(
+        system=dafBase.DateTime.MJD)
+
+    wcs = exposure.getWcs()
+
+    data = []
+    for idx, (x, y) in enumerate(zip(rand_x, rand_y)):
+        coord = wcs.pixelToSky(x, y)
+        htmIdx = pixelator.index(coord.getVector())
+        newObject = {"ra": coord.getRa().asDegrees(),
+                     "decl": coord.getRa().asDegrees(),
+                     "radecTai": midPointTaiMJD,
+                     "diaObjectId": idx,
+                     "pixelId": htmIdx,
+                     "pmParallaxNdata": 0,
+                     "nearbyObj1": 0,
+                     "nearbyObj2": 0,
+                     "nearbyObj3": 0}
+        for f in ["u", "g", "r", "i", "z", "y"]:
+            newObject["%sPSFluxNdata" % f] = 0
+        data.append(newObject)
+
+    return pd.DataFrame(data=data)
+
+
+def makeDiaSources(nSources, diaObjectIds, exposure, pixelator):
+    """Make a test set of DiaSources.
+
+    Parameters
+    ----------
+    nSources : `int`
+        Number of sources to create.
+    diaObjectIds : `numpy.ndarray`
+        Integer Ids of diaobjects to "associate" with the DiaSources.
+    exposure : `lsst.afw.image.Exposure`
+        Exposure to create sources over.
+    pixelator : `lsst.sphgeom.HtmPixelization`
+        Object to compute spatial indicies from.
+
+    Returns
+    -------
+    diaSources : `pandas.DataFrame`
+        DiaSources generated across the exposure.
+    """
+    bbox = geom.Box2D(exposure.getBBox())
+    rand_x = np.random.uniform(bbox.getMinX(), bbox.getMaxX(), size=nSources)
+    rand_y = np.random.uniform(bbox.getMinY(), bbox.getMaxY(), size=nSources)
+    rand_ids = diaObjectIds[np.random.randint(len(diaObjectIds), size=nSources)]
+
+    midPointTaiMJD = exposure.getInfo().getVisitInfo().getDate().get(
+        system=dafBase.DateTime.MJD)
+
+    wcs = exposure.getWcs()
+
+    data = []
+    for idx, (x, y, objId) in enumerate(zip(rand_x, rand_y, rand_ids)):
+        coord = wcs.pixelToSky(x, y)
+        htmIdx = pixelator.index(coord.getVector())
+        data.append({"ra": coord.getRa().asDegrees(),
+                     "decl": coord.getRa().asDegrees(),
+                     "diaObjectId": objId,
+                     "diaSourceId": idx,
+                     "pixelId": htmIdx,
+                     "midPointTai": midPointTaiMJD})
+
+    return pd.DataFrame(data=data)
+
+
+class TestLoadDiaCatalogs(unittest.TestCase):
+
+    def setUp(self):
+        np.random.seed(1234)
+
+        # CFHT Filters from the camera mapper.
+        self.filter_names = ["g"]
+        afwImageUtils.resetFilters()
+        afwImageUtils.defineFilter('g', lambdaEff=487, alias="g.MP9401")
+
+        self.tmp_file, self.db_file = tempfile.mkstemp(
+            dir=os.path.dirname(__file__))
+
+        self.apdbConfig = ApdbConfig()
+        self.apdbConfig.db_url = "sqlite:///" + self.db_file
+        self.apdbConfig.isolation_level = "READ_UNCOMMITTED"
+        self.apdbConfig.dia_object_index = "baseline"
+        self.apdbConfig.dia_object_columns = []
+        self.apdbConfig.schema_file = _data_file_name(
+            "apdb-schema.yaml", "dax_apdb")
+        self.apdbConfig.column_map = _data_file_name(
+            "apdb-ap-pipe-afw-map.yaml", "ap_association")
+        self.apdbConfig.extra_schema_file = _data_file_name(
+            "apdb-ap-pipe-schema-extra.yaml", "ap_association")
+
+        self.apdb = Apdb(config=self.apdbConfig,
+                         afw_schemas=dict(DiaObject=make_dia_object_schema(),
+                                          DiaSource=make_dia_source_schema()))
+        self.apdb.makeSchema()
+
+        # Expected HTM pixel ranges for max range=4 and level = 20. This
+        # set of pixels should be same for the WCS created by default in
+        # makeExposure and for one with a flipped y axis.
+        self.ranges = np.sort(np.array([15154776375296, 15154779521024,
+                                        15154788958208, 15154792103936]))
+
+        self.pixelator = sphgeom.HtmPixelization(20)
+        self.exposure = makeExposure(False, False)
+
+        self.diaObjects = makeDiaObjects(20, self.exposure, self.pixelator)
+        self.diaSources = makeDiaSources(
+            100,
+            self.diaObjects["diaObjectId"].to_numpy(),
+            self.exposure,
+            self.pixelator)
+
+        self.apdb.storeDiaSources(self.diaSources)
+        self.dateTime = \
+            self.exposure.getInfo().getVisitInfo().getDate().toPython()
+        self.apdb.storeDiaObjects(self.diaObjects,
+                                  self.dateTime)
+
+    def tearDown(self):
+        del self.tmp_file
+        os.remove(self.db_file)
+        del self.db_file
+
+    def testRun(self):
+        """Test the full run method for the loader.
+        """
+        diaLoader = LoadDiaCatalogsTask()
+        result = diaLoader.run(self.exposure, self.apdb)
+
+        self.assertEqual(len(result.diaObjects), len(self.diaObjects))
+        self.assertEqual(len(result.diaSources), len(self.diaSources))
+
+    def testLoadDiaObjects(self):
+        """Test that the correct number of diaObjects are loaded.
+        """
+        diaLoader = LoadDiaCatalogsTask()
+        normPixels = diaLoader._getPixelRanges(self.exposure)
+        diaObjects = diaLoader.loadDiaObjects(normPixels,
+                                              self.apdb)
+        self.assertEqual(len(diaObjects), len(self.diaObjects))
+
+    def testLoadDiaSourcesByPixelId(self):
+        """Test that the correct number of diaSources are loaded.
+
+        Also check that they can be properly loaded both by location and
+        ``diaObjectId``.
+        """
+        self._testLoadDiaSources(True)
+
+    def testLoadDiaSourcesByDiaObjectId(self):
+        """Test that the correct number of diaSources are loaded.
+
+        Also check that they can be properly loaded both by location and
+        ``diaObjectId``.
+        """
+        self._testLoadDiaSources(False)
+
+    def _testLoadDiaSources(self, loadByPixelId):
+        """Test that DiaSources are loaded correctly.
+
+        Parameters
+        ----------
+        loadByPixelId : `bool`
+            Load DiaSources by ``pixelId`` if ``True`` and by ``diaObjectId``
+            if ``False``.
+        """
+        diaConfig = LoadDiaCatalogsConfig()
+        diaConfig.loadDiaSourcesByPixelId = loadByPixelId
+        diaLoader = LoadDiaCatalogsTask(config=diaConfig)
+
+        normPixels = diaLoader._getPixelRanges(self.exposure)
+        diaSources = diaLoader.loadDiaSources(self.diaObjects,
+                                              normPixels,
+                                              self.dateTime,
+                                              self.apdb)
+        self.assertEqual(len(diaSources), len(self.diaSources))
+
+    def testGetPixelRanges(self):
+        """Test the same pixels are returned for flips/ordering changes in
+        the WCS.
+        """
+        diaConfig = LoadDiaCatalogsConfig()
+        diaConfig.htmMaxRanges = 4
+        diaLoader = LoadDiaCatalogsTask(config=diaConfig)
+
+        # Make two exposures, one with a flipped y axis to get left vs. right
+        # handed.
+        exposure = makeExposure(False, False)
+        exposureFlip = makeExposure(False, True)
+
+        normPixels = diaLoader._getPixelRanges(exposure)
+        flipPixels = diaLoader._getPixelRanges(exposureFlip)
+
+        for normPix, flipPix, testPix in zip(
+                np.sort(np.array(normPixels).flatten()),
+                np.sort(np.array(flipPixels).flatten()),
+                self.ranges):
+            self.assertEqual(normPix, flipPix)
+            self.assertEqual(normPix, testPix)
+            self.assertEqual(flipPix, testPix)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
Restructure ap_association to accomidate preloading.

Remove DiaObject/Source loading from association.
Change sphgeom HTM indexer.

Debug HTM diaCalc plugin.

Add mock Apdb to DiaForced unittest.

Change to sphgeom indexer.

Change update_dia_objects unittest.

Add htmIndex calculation to unittest.

Debug update diaObjects.

Edit association run method unittest.

Debug test_run.

Debug all association tests.

Create loadDiaCatalogs tests.

Add getPixelRanges test.

Add unittest for getPixelRanges

Debug getPixelRanges test.

Add object, source, and run tests.

debug loadDiaCatalogs unittests.

Add comment to diaCaluclation.