### PR TITLE
DM-25040: ap_association uses physical filter in Gen 3

### DIFF
--- a/python/lsst/ap/association/afwUtils.py
+++ b/python/lsst/ap/association/afwUtils.py
@@ -805,7 +805,7 @@ def get_ccd_visit_info_from_exposure(exposure):
     #  flux zero point error ``counts``]
     values = {'ccdVisitId': visit_info.getExposureId(),
               'ccdNum': exposure.getDetector().getId(),
-              'filterName': filter_obj.getName(),
+              'filterName': filter_obj.getCanonicalName(),  # use abstract filter
               'filterId': filter_obj.getId(),
               'ra': sphPoint.getRa().asDegrees(),
               'decl': sphPoint.getDec().asDegrees(),

--- a/python/lsst/ap/association/afwUtils.py
+++ b/python/lsst/ap/association/afwUtils.py
@@ -35,7 +35,6 @@ __all__ = ["make_dia_object_schema",
 from collections import OrderedDict as oDict
 
 import lsst.afw.table as afwTable
-from lsst.daf.base import DateTime
 
 
 def make_dia_object_schema(filter_names=None):
@@ -773,45 +772,3 @@ def getCcdVisitSchemaSql():
                   ("expMidptMJD", "REAL"),
                   ("calibrationMean", "REAL"),
                   ("calibrationErr", "REAL")])
-
-
-def get_ccd_visit_info_from_exposure(exposure):
-    """
-    Extract info on the ccd and visit from the exposure.
-
-    Parameters
-    ----------
-    exposure : `lsst.afw.image.Exposure`
-        Exposure to store information from.
-
-    Returns
-    -------
-    values : `dict` of ``values``
-        List values representing info taken from the exposure.
-    """
-    visit_info = exposure.getInfo().getVisitInfo()
-    date = visit_info.getDate()
-    sphPoint = exposure.getWcs().getSkyOrigin()
-    filter_obj = exposure.getFilter()
-    # Values list is:
-    # [CcdVisitId ``int``,
-    #  ccdNum ``int``,
-    #  filterName ``str``,
-    #  RA WCS center ``degrees``,
-    #  DEC WCS center ``degrees``,
-    #  exposure time ``seconds``,
-    #  dateTimeMJD ``days``,
-    #  flux zero point ``counts``,
-    #  flux zero point error ``counts``]
-    values = {'ccdVisitId': visit_info.getExposureId(),
-              'ccdNum': exposure.getDetector().getId(),
-              'filterName': filter_obj.getCanonicalName(),  # use abstract filter
-              'filterId': filter_obj.getId(),
-              'ra': sphPoint.getRa().asDegrees(),
-              'decl': sphPoint.getDec().asDegrees(),
-              'expTime': visit_info.getExposureTime(),
-              'expMidptMJD': date.get(system=DateTime.MJD),
-              'calibrationMean': exposure.getPhotoCalib().getCalibrationMean(),
-              'calibrationErr': exposure.getPhotoCalib().getCalibrationErr(),
-              'photoCalib': exposure.getPhotoCalib()}
-    return values

--- a/python/lsst/ap/association/mapApData.py
+++ b/python/lsst/ap/association/mapApData.py
@@ -231,7 +231,8 @@ class MapDiaSourceTask(MapApDataTask):
         ccdVisitId = visit_info.getExposureId()
         midPointTaiMJD = visit_info.getDate().get(system=DateTime.MJD)
         filterId = exposure.getFilter().getId()
-        filterName = exposure.getFilter().getName()
+        # canonical name should always be the abstract filter (in Gen 3 sense)
+        filterName = exposure.getFilter().getCanonicalName()
         wcs = exposure.getWcs()
 
         photoCalib = exposure.getPhotoCalib()

--- a/tests/test_association_task.py
+++ b/tests/test_association_task.py
@@ -323,7 +323,7 @@ class TestAssociationTask(unittest.TestCase):
                 dia_source=dia_source,
                 flux=10000,
                 fluxErr=100,
-                filterName=self.exposure.getFilter().getName(),
+                filterName=self.exposure.getFilter().getCanonicalName(),
                 filterId=self.exposure.getFilter().getId(),
                 ccdVisitId=self.exposure.getInfo().getVisitInfo().getExposureId(),
                 midPointTai=self.exposure.getInfo().getVisitInfo().getDate().get(system=dafBase.DateTime.MJD))

--- a/tests/test_map_ap_data.py
+++ b/tests/test_map_ap_data.py
@@ -126,7 +126,7 @@ class TestAPDataMapperTask(unittest.TestCase):
             date=dafBase.DateTime(nsecs=1400000000 * 10**9))
         self.exposure.setDetector(detector)
         self.exposure.getInfo().setVisitInfo(visit)
-        self.exposure.setFilter(afwImage.Filter('g'))
+        self.exposure.setFilter(afwImage.Filter('g.MP9401'))
         scale = 2
         scaleErr = 1
         self.photoCalib = afwImage.PhotoCalib(scale, scaleErr)
@@ -192,6 +192,8 @@ class TestAPDataMapperTask(unittest.TestCase):
                 self.assertEqual(outObj["dipMeanFlux"], expectedMeanDip)
                 self.assertEqual(outObj["dipFluxDiff"], expectedDiffFlux)
                 self.assertAlmostEqual(outObj["dipLength"], expectedLength)
+        # Mapper should always emit standardized filters
+        self.assertEqual(outObj["filterName"], 'g')
 
     def _create_map_dia_source_config(self):
         """Create a test config for use in MapDiaSourceTask.

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -154,7 +154,7 @@ def makeDiaSources(nSources, diaObjectIds, exposure):
                      "diaSourceId": idx,
                      "pixelId": htmIdx,
                      "midPointTai": midPointTaiMJD + 1.0 * idx,
-                     "filterName": exposure.getFilter().getName(),
+                     "filterName": exposure.getFilter().getCanonicalName(),
                      "filterId": 0,
                      "psNdata": 0,
                      "trailNdata": 0,


### PR DESCRIPTION
This PR fixes a bug that caused `MapDiaSourceTask` to sometimes report observatory-specific filters, which would then get propagated to table columns. It updates all `ap_association` code to standardize filter names.