### PR TITLE
DM-21939: Create Gen 3 AP Pipeline

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -85,7 +85,7 @@ class DiaPipelineConnections(pipeBase.PipelineTaskConnections,
         doc="Marker dataset storing the configuration of the Apdb for each "
             "visit/detector. Used to signal the completion of the pipeline.",
         name="apdb_marker",
-        storageClass="",
+        storageClass="Config",
         dimensions=("instrument", "visit", "detector"),
     )
 
@@ -246,4 +246,4 @@ class DiaPipelineTask(pipeBase.PipelineTask):
                                    None,
                                    ccdExposureIdBits)
 
-        return pipeBase.Struct(apdb_marker=self.config.apdb.value)
+        return pipeBase.Struct(apdbMarker=self.config.apdb.value)

--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -52,25 +52,25 @@ __all__ = ("DiaPipelineConfig",
 
 class DiaPipelineConnections(pipeBase.PipelineTaskConnections,
                              dimensions=("instrument", "visit", "detector"),
-                             defaultTemplates={"coaddName": "deep"}):
+                             defaultTemplates={"coaddName": "deep", "fakesType": ""}):
     """Butler connections for DiaPipelineTask.
     """
     diaSourceSchema = connTypes.InitInput(
         doc="Schema of the DiaSource catalog produced during image "
             "differencing",
-        name="{coaddName}Diff_diaSrc_schema",
+        name="{fakesType}{coaddName}Diff_diaSrc_schema",
         storageClass="SourceCatalog",
         multiple=True
     )
     diaSourceCat = connTypes.Input(
         doc="Catalog of DiaSources produced during image differencing.",
-        name="{coaddName}Diff_diaSrc",
+        name="{fakesType}{coaddName}Diff_diaSrc",
         storageClass="SourceCatalog",
         dimensions=("instrument", "visit", "detector"),
     )
     diffIm = connTypes.Input(
         doc="Difference image on which the DiaSources were detected.",
-        name="{coaddName}Diff_differenceExp",
+        name="{fakesType}{coaddName}Diff_differenceExp",
         storageClass="ExposureF",
         dimensions=("instrument", "visit", "detector"),
     )
@@ -160,7 +160,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
             afw_schemas=dict(DiaObject=make_dia_object_schema(),
                              DiaSource=make_dia_source_schema()))
         self.makeSubtask("diaSourceDpddifier",
-                         inputSchema=initInputs["diaSourceSchema"])
+                         inputSchema=initInputs["diaSourceSchema"].schema)
         self.makeSubtask("diaCatalogLoader")
         self.makeSubtask("associator")
         self.makeSubtask("diaForcedSource")

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -24,6 +24,7 @@ import unittest
 
 import lsst.afw.image as afwImage
 import lsst.afw.table as afwTable
+import lsst.pipe.base as pipeBase
 from lsst.utils import getPackageDir
 import lsst.utils.tests
 from unittest.mock import patch, Mock, DEFAULT
@@ -106,8 +107,9 @@ class TestDiaPipelineTask(unittest.TestCase):
             result = task.run(diaSrc, diffIm, exposure, ccdExposureIdBits)
             for subtaskName in subtasksToMock:
                 getattr(task, subtaskName).run.assert_called_once()
-            self.assertEqual(result.apdb_marker.db_url, "sqlite://")
-            self.assertEqual(result.apdb_marker.isolation_level,
+            pipeBase.testUtils.assertValidOutput(task, result)
+            self.assertEqual(result.apdbMarker.db_url, "sqlite://")
+            self.assertEqual(result.apdbMarker.isolation_level,
                              "READ_UNCOMMITTED")
 
 

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -50,9 +50,11 @@ class TestDiaPipelineTask(unittest.TestCase):
         return config
 
     def setUp(self):
-        self.srcSchema = afwTable.SourceTable.makeMinimalSchema()
-        self.srcSchema.addField("base_PixelFlags_flag", type="Flag")
-        self.srcSchema.addField("base_PixelFlags_flag_offimage", type="Flag")
+        # schemas are persisted in both Gen 2 and Gen 3 butler as prototypical catalogs
+        srcSchema = afwTable.SourceTable.makeMinimalSchema()
+        srcSchema.addField("base_PixelFlags_flag", type="Flag")
+        srcSchema.addField("base_PixelFlags_flag_offimage", type="Flag")
+        self.srcSchema = afwTable.SourceCatalog(srcSchema)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
This PR modifies `DiaPipelineTask`'s inputs to match `ImageDifferenceTask`'s outputs, as modified by lsst/pipe_tasks#390. The most substantial change is having it take its input "schema" as a catalog, as this is how schemas are persisted by the Butler.