### PR TITLE
DM-24327: Include coadd cutouts in alert packets

### DIFF
--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -119,6 +119,7 @@ class PackageAlertsTask(pipeBase.Task):
         self._patchDiaSources(diaSrcHistory)
         ccdVisitId = diffIm.getInfo().getVisitInfo().getExposureId()
         diffImPhotoCalib = diffIm.getPhotoCalib()
+        templatePhotoCalib = template.getPhotoCalib()
         for srcIndex, diaSource in diaSourceCat.iterrows():
             # Get all diaSources for the associated diaObject.
             diaObject = diaObjectCat.loc[srcIndex[0]]
@@ -136,7 +137,12 @@ class PackageAlertsTask(pipeBase.Task):
                 sphPoint,
                 diffImPhotoCalib)
 
-            templateCutout = None
+            templateBBox = self.createDiaSourceBBox(diaSource["bboxSize"])
+            templateCutout = self.createCcdDataCutout(
+                template.getCutout(sphPoint, templateBBox),
+                sphPoint,
+                templatePhotoCalib)
+
             # TODO: Create alertIds DM-24858
             alertId = diaSource["diaSourceId"]
             alerts.append(
@@ -308,8 +314,7 @@ class PackageAlertsTask(pipeBase.Task):
         alert['ssObject'] = None
 
         alert['cutoutDifference'] = self.streamCcdDataToBytes(diffImCutout)
-        # TODO: add template cutouts in DM-24327
-        alert["cutoutTemplate"] = None
+        alert["cutoutTemplate"] = self.streamCcdDataToBytes(templateCutout)
 
         return alert
 

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -82,6 +82,7 @@ class TestDiaPipelineTask(unittest.TestCase):
             initInputs={"diaSourceSchema": self.srcSchema})
         diffIm = Mock(spec=afwImage.ExposureF)
         exposure = Mock(spec=afwImage.ExposureF)
+        template = Mock(spec=afwImage.ExposureF)
         diaSrc = Mock(sepc=afwTable.SourceCatalog)
         ccdExposureIdBits = 32
 
@@ -104,7 +105,11 @@ class TestDiaPipelineTask(unittest.TestCase):
         with patch.multiple(
             task, **{task: DEFAULT for task in subtasksToMock + ["apdb"]}
         ):
-            result = task.run(diaSrc, diffIm, exposure, ccdExposureIdBits)
+            result = task.run(diaSrc,
+                              diffIm,
+                              exposure,
+                              template,
+                              ccdExposureIdBits)
             for subtaskName in subtasksToMock:
                 getattr(task, subtaskName).run.assert_called_once()
             pipeBase.testUtils.assertValidOutput(task, result)

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -434,7 +434,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
                 objSources,
                 objForcedSources,
                 ccdCutout,
-                None)
+                ccdCutout)
             self.assertEqual(len(alert), 9)
 
             self.assertEqual(alert["alertId"], alertId)
@@ -442,7 +442,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
             self.assertEqual(alert["cutoutDifference"],
                              cutoutBytes)
             self.assertEqual(alert["cutoutTemplate"],
-                             None)
+                             cutoutBytes)
 
     def testRun(self):
         """Test the run method of package alerts.
@@ -457,7 +457,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
                           self.diaSourceHistory,
                           self.diaForcedSources,
                           self.exposure,
-                          None,
+                          self.exposure,
                           None)
 
         ccdVisitId = self.exposure.getInfo().getVisitInfo().getExposureId()


### PR DESCRIPTION
Use within packageAlerts.

Debug unittests.