### PR TITLE
DM-25746: filterName in APDB needs to be one of g, r, i, z, or y

### DIFF
--- a/python/lsst/ap/association/mapApData.py
+++ b/python/lsst/ap/association/mapApData.py
@@ -232,7 +232,8 @@ class MapDiaSourceTask(MapApDataTask):
         midPointTaiMJD = visit_info.getDate().get(system=DateTime.MJD)
         filterId = exposure.getFilter().getId()
         # canonical name should always be the abstract filter (in Gen 3 sense)
-        filterName = exposure.getFilter().getCanonicalName()
+        # TODO DM-21333: Remove [0] (first character only) workaround
+        filterName = exposure.getFilter().getCanonicalName()[0]
         wcs = exposure.getWcs()
 
         photoCalib = exposure.getPhotoCalib()

--- a/tests/test_association_task.py
+++ b/tests/test_association_task.py
@@ -323,7 +323,8 @@ class TestAssociationTask(unittest.TestCase):
                 dia_source=dia_source,
                 flux=10000,
                 fluxErr=100,
-                filterName=self.exposure.getFilter().getCanonicalName(),
+                # TODO DM-21333: Remove [0] (first character only) workaround
+                filterName=self.exposure.getFilter().getCanonicalName()[0],
                 filterId=self.exposure.getFilter().getId(),
                 ccdVisitId=self.exposure.getInfo().getVisitInfo().getExposureId(),
                 midPointTai=self.exposure.getInfo().getVisitInfo().getDate().get(system=dafBase.DateTime.MJD))

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -157,7 +157,8 @@ def makeDiaSources(nSources, diaObjectIds, exposure):
                      "diaSourceId": idx,
                      "pixelId": htmIdx,
                      "midPointTai": midPointTaiMJD + 1.0 * idx,
-                     "filterName": exposure.getFilter().getCanonicalName(),
+                     # TODO DM-21333: Remove [0] (first character only) workaround
+                     "filterName": exposure.getFilter().getCanonicalName()[0],
                      "filterId": 0,
                      "psNdata": 0,
                      "trailNdata": 0,
@@ -197,7 +198,8 @@ def makeDiaForcedSources(nSources, diaObjectIds, exposure):
                      "ccdVisitId": ccdVisitId + idx,
                      "diaObjectId": objId,
                      "midPointTai": midPointTaiMJD + 1.0 * idx,
-                     "filterName": exposure.getFilter().getCanonicalName(),
+                     # TODO DM-21333: Remove [0] (first character only) workaround
+                     "filterName": exposure.getFilter().getCanonicalName()[0],
                      "flags": 0})
 
     return pd.DataFrame(data=data)


### PR DESCRIPTION
Explicitly use `getCanonicalFilter()[0]` as an interim solution.