### PR TITLE
DM-25826: Explicitly cast alert data to a list in tests

### DIFF
--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -34,7 +34,6 @@ import lsst.afw.geom as afwGeom
 import lsst.geom as geom
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
-from lsst.utils import getPackageDir
 
 
 """Methods for packaging Apdb and Pipelines data into Avro alerts.
@@ -47,10 +46,7 @@ class PackageAlertsConfig(pexConfig.Config):
     schemaFile = pexConfig.Field(
         dtype=str,
         doc="Schema definition file for the avro alerts.",
-        default=os.path.join(getPackageDir("alert_packet"),
-                             "schema",
-                             *[str(x) for x in alertPack.get_latest_schema_version()],
-                             "lsst.alert.avsc")
+        default=alertPack.get_path_to_latest_schema()
     )
     minCutoutSize = pexConfig.RangeField(
         dtype=int,

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -464,8 +464,9 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
 
         ccdVisitId = self.exposure.getInfo().getVisitInfo().getExposureId()
         with open(os.path.join(tempdir, f"{ccdVisitId}.avro"), 'rb') as f:
-            writer_schema, data = \
+            writer_schema, data_stream = \
                 packageAlerts.alertSchema.retrieve_alerts(f)
+            data = list(data_stream)
         self.assertEqual(len(data), len(self.diaSources))
         for idx, alert in enumerate(data):
             for key, value in alert["diaSource"].items():


### PR DESCRIPTION
In https://github.com/lsst/alert_packet/pull/21, we would like to change lsst.alert.packet's behavior to stream alerts out from disk rather than loading them entirely into memory, since alert files might be very large. Technically, this breaks no APIs, since the documented return value is an "iterable."

Making that change requires this one: change the test code so that it loads data into a list explicitly.