### PR TITLE
Use iat accessor for pandas 1.1.0 compatibility

### DIFF
--- a/python/lsst/ap/association/association.py
+++ b/python/lsst/ap/association/association.py
@@ -138,7 +138,7 @@ class AssociationTask(pipeBase.Task):
         mergedDiaSourceHistory = diaSourceHistory.append(diaSources, sort=True)
 
         # Get the current filter being processed.
-        filterName = diaSources["filterName"][0]
+        filterName = diaSources["filterName"].iat[0]
 
         # Update previously existing DIAObjects with the information from their
         # newly association DIASources and create new DIAObjects from


### PR DESCRIPTION
Pandas 1.1.0 now throws a KeyError in parts of the code. The fix is to use the `iat` accessor.