### PR TITLE
DM-21919: Run ap_verify end-to-end in Gen 3

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -190,7 +190,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
         butlerQC.put(outputs, outputRefs)
 
     @pipeBase.timeMethod
-    def run(self, diaSourceCat, diffIm, exposure, template, ccdExposureIdBits):
+    def run(self, diaSourceCat, diffIm, exposure, warpedExposure, ccdExposureIdBits):
         """Process DiaSources and DiaObjects.
 
         Load previous DiaObjects and their DiaSource history. Calibrate the
@@ -208,7 +208,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
         exposure : `lsst.afw.image.ExposureF`
             Calibrated exposure differenced with a template to create
             ``diffIm``.
-        template : `lsst.afw.image.ExposureF`
+        warpedExposure : `lsst.afw.image.ExposureF`
             Template exposure used to create diffIm.
         ccdExposureIdBits : `int`
             Number of bits used for a unique ``ccdVisitId``.
@@ -262,7 +262,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
                                    loaderResult.diaSources,
                                    diaForcedSources,
                                    diffIm,
-                                   template,
+                                   warpedExposure,
                                    ccdExposureIdBits)
 
         return pipeBase.Struct(apdbMarker=self.config.apdb.value)

--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -236,9 +236,9 @@ class TotalUnassociatedDiaObjectsMetricTask(ApdbMetricTask):
             Raised if outputDataId is not empty
         """
         # All data ID types define keys()
-        if outputDataId.keys():
-            raise ValueError("%s must not be associated with specific data IDs."
-                             % self.config.metricName)
+        if outputDataId.keys() - {'instrument'}:
+            raise ValueError("%s must not be associated with specific data IDs (gave %s)."
+                             % (self.config.metricName, outputDataId))
 
         try:
             nUnassociatedDiaObjects = dbHandle.countUnassociatedObjects()


### PR DESCRIPTION
This PR fixes a bug in `DiaPipelineTask` that got missed in review, and prevents `TotalUnassociatedDiaObjectsMetricTask` from calling an error when run at instrument granularity (it is still not clear whether tasks that access the APDB should be at repository or instrument granularity, but their current connections declare the latter).

Must be merged together with lsst/ap_pipe#57.