### PR TITLE
DM-26040: Add AP timing metrics for DiaPipelineTask and all subtasks

### DIFF
--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -129,6 +129,7 @@ class DiaForcedSourceTask(pipeBase.Task):
         self.makeSubtask("forcedMeasurement",
                          refSchema=afwTable.SourceTable.makeMinimalSchema())
 
+    @pipeBase.timeMethod
     def run(self, dia_objects, expIdBits, exposure, diffim):
         """Measure forced sources on the direct and difference images.
 

--- a/python/lsst/ap/association/mapApData.py
+++ b/python/lsst/ap/association/mapApData.py
@@ -75,6 +75,7 @@ class MapApDataTask(pipeBase.Task):
                 outputName,
                 True)
 
+    @pipeBase.timeMethod
     def run(self, inputCatalog, exposure=None):
         """Copy data from the inputCatalog into an output catalog with
         requested columns.
@@ -208,6 +209,7 @@ class MapDiaSourceTask(MapApDataTask):
                         "schema. Please check that the requested input column "
                         "exists." % outputFlag['columnName'])
 
+    @pipeBase.timeMethod
     def run(self, inputCatalog, exposure, return_pandas=False):
         """Copy data from the inputCatalog into an output catalog with
         requested columns.

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -75,6 +75,7 @@ class PackageAlertsTask(pipeBase.Task):
         self.alertSchema = alertPack.Schema.from_file(self.config.schemaFile)
         os.makedirs(self.config.alertWriteLocation, exist_ok=True)
 
+    @pipeBase.timeMethod
     def run(self,
             diaSourceCat,
             diaObjectCat,


### PR DESCRIPTION
This PR adds `@timeMethod` decorators to all tasks' `run` methods, so that their runtime can be measured.