### PR TITLE
DM-25990: Reprocess HSC COSMOS medium dataset with ap_pipe

### DIFF
--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -25,6 +25,8 @@ locations.
 
 __all__ = ["DiaForcedSourceTask", "DiaForcedSourcedConfig"]
 
+import numpy as np
+
 import lsst.afw.table as afwTable
 from lsst.daf.base import DateTime
 import lsst.geom as geom
@@ -130,14 +132,24 @@ class DiaForcedSourceTask(pipeBase.Task):
                          refSchema=afwTable.SourceTable.makeMinimalSchema())
 
     @pipeBase.timeMethod
-    def run(self, dia_objects, expIdBits, exposure, diffim):
+    def run(self,
+            dia_objects,
+            updatedDiaObjectIds,
+            expIdBits,
+            exposure,
+            diffim):
         """Measure forced sources on the direct and difference images.
 
         Parameters
         ----------
         dia_objects : `pandas.DataFrame`
             Catalog of previously observed and newly created DiaObjects
-            contained within the difference and direct images.
+            contained within the difference and direct images. DiaObjects
+            must be indexed on the ``diaObjectId`` column.
+        updatedDiaObjectIds : `numpy.ndarray`
+            Array of diaObjectIds that were updated during this dia processing.
+            Used to assure that the pipeline includes all diaObjects that were
+            updated in case one falls on the edge of the CCD.
         expIdBits : `int`
             Bit length of the exposure id.
         exposure : `lsst.afw.image.Exposure`
@@ -179,6 +191,7 @@ class DiaForcedSourceTask(pipeBase.Task):
                                                           exposure)
 
         output_forced_sources = self._trim_to_exposure(output_forced_sources,
+                                                       updatedDiaObjectIds,
                                                        exposure)
         return output_forced_sources.set_index(
             ["diaObjectId", "diaForcedSourceId"],
@@ -273,13 +286,17 @@ class DiaForcedSourceTask(pipeBase.Task):
 
         return output_catalog
 
-    def _trim_to_exposure(self, catalog, exposure):
+    def _trim_to_exposure(self, catalog, updatedDiaObjectIds, exposure):
         """Remove DiaForcedSources that are outside of the bounding box region.
 
         Paramters
         ---------
         catalog : `pandas.DataFrame`
             DiaForcedSources to check against the exposure bounding box.
+        updatedDiaObjectIds : `numpy.ndarray`
+            Array of diaObjectIds that were updated during this dia processing.
+            Used to assure that the pipeline includes all diaObjects that were
+            updated in case one falls on the edge of the CCD.
         exposure : `lsst.afw.image.Exposure`
             Exposure to check against.
 
@@ -294,4 +311,7 @@ class DiaForcedSourceTask(pipeBase.Task):
         xS = catalog.loc[:, "x"]
         yS = catalog.loc[:, "y"]
 
-        return catalog[bbox.contains(xS, yS)]
+        return catalog[
+            np.logical_or(bbox.contains(xS, yS),
+                          np.isin(catalog.loc[:, "diaObjectId"],
+                                  updatedDiaObjectIds))]

--- a/python/lsst/ap/association/mapApData.py
+++ b/python/lsst/ap/association/mapApData.py
@@ -233,8 +233,8 @@ class MapDiaSourceTask(MapApDataTask):
         ccdVisitId = visit_info.getExposureId()
         midPointTaiMJD = visit_info.getDate().get(system=DateTime.MJD)
         filterId = exposure.getFilter().getId()
-        # canonical name should always be the abstract filter (in Gen 3 sense)
-        # TODO DM-21333: Remove [0] (first character only) workaround
+        # TODO DM-27170: fix this [0] workaround which gets a single character
+        # representation of the band.
         filterName = exposure.getFilter().getCanonicalName()[0]
         wcs = exposure.getWcs()
 

--- a/tests/test_association_task.py
+++ b/tests/test_association_task.py
@@ -323,7 +323,8 @@ class TestAssociationTask(unittest.TestCase):
                 dia_source=dia_source,
                 flux=10000,
                 fluxErr=100,
-                # TODO DM-21333: Remove [0] (first character only) workaround
+                # TODO DM-27170: fix this [0] workaround which gets a
+                # single character representation of the band.
                 filterName=self.exposure.getFilter().getCanonicalName()[0],
                 filterId=self.exposure.getFilter().getId(),
                 ccdVisitId=self.exposure.getInfo().getVisitInfo().getExposureId(),

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -157,7 +157,8 @@ def makeDiaSources(nSources, diaObjectIds, exposure):
                      "diaSourceId": idx,
                      "pixelId": htmIdx,
                      "midPointTai": midPointTaiMJD + 1.0 * idx,
-                     # TODO DM-21333: Remove [0] (first character only) workaround
+                     # TODO DM-27170: fix this [0] workaround which gets a
+                     # single character representation of the band.
                      "filterName": exposure.getFilter().getCanonicalName()[0],
                      "filterId": 0,
                      "psNdata": 0,
@@ -198,7 +199,8 @@ def makeDiaForcedSources(nSources, diaObjectIds, exposure):
                      "ccdVisitId": ccdVisitId + idx,
                      "diaObjectId": objId,
                      "midPointTai": midPointTaiMJD + 1.0 * idx,
-                     # TODO DM-21333: Remove [0] (first character only) workaround
+                     # TODO DM-27170: fix this [0] workaround which gets a
+                     # single character representation of the band.
                      "filterName": exposure.getFilter().getCanonicalName()[0],
                      "flags": 0})
 


### PR DESCRIPTION
As in DM-25746, this is a temporary workaround to enable R2 and I2 processing with ap_pipe. All the APDB filter name columns presently require a single character, and the DiaForcedSource table is no exception.