### PR TITLE
DM-30985: Use lazy evaluation of functor file and flag map

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -34,7 +34,6 @@ import lsst.dax.apdb as daxApdb
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as connTypes
-from lsst.utils import getPackageDir
 
 from lsst.ap.association import (
     AssociationTask,
@@ -225,7 +224,7 @@ class DiaPipelineConfig(pipeBase.PipelineTaskConfig,
         self.apdb.dia_object_index = "baseline"
         self.apdb.dia_object_columns = []
         self.apdb.extra_schema_file = os.path.join(
-            getPackageDir("ap_association"),
+            "${AP_ASSOCIATION_DIR}",
             "data",
             "apdb-ap-pipe-schema-extra.yaml")
 

--- a/python/lsst/ap/association/transformDiaSourceCatalog.py
+++ b/python/lsst/ap/association/transformDiaSourceCatalog.py
@@ -82,7 +82,7 @@ class TransformDiaSourceCatalogConfig(pipeBase.PipelineTaskConfig,
         dtype=str,
         doc='Path to YAML file specifying Science DataModel functors to use '
             'when copying columns and computing calibrated values.',
-        default=os.path.join(getPackageDir("ap_association"),
+        default=os.path.join("${AP_ASSOCIATION_DIR}",
                              "data",
                              "DiaSource.yaml")
     )

--- a/python/lsst/ap/association/transformDiaSourceCatalog.py
+++ b/python/lsst/ap/association/transformDiaSourceCatalog.py
@@ -34,7 +34,6 @@ import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as connTypes
 from lsst.pipe.tasks.postprocess import TransformCatalogBaseTask
 from lsst.pipe.tasks.parquetTable import ParquetTable
-from lsst.utils import getPackageDir
 
 
 class TransformDiaSourceCatalogConnections(pipeBase.PipelineTaskConnections,
@@ -74,7 +73,7 @@ class TransformDiaSourceCatalogConfig(pipeBase.PipelineTaskConfig,
     flagMap = pexConfig.Field(
         dtype=str,
         doc="Yaml file specifying SciencePipelines flag fields to bit packs.",
-        default=os.path.join(getPackageDir("ap_association"),
+        default=os.path.join("${AP_ASSOCIATION_DIR}",
                              "data",
                              "association-flag-map.yaml"),
     )
@@ -111,7 +110,8 @@ class TransformDiaSourceCatalogTask(TransformCatalogBaseTask):
         """Setup all flag bit packings.
         """
         self.bit_pack_columns = []
-        with open(self.config.flagMap) as yaml_stream:
+        flag_map_file = os.path.expandvars(self.config.flagMap)
+        with open(flag_map_file) as yaml_stream:
             table_list = list(yaml.safe_load_all(yaml_stream))
             for table in table_list:
                 if table['tableName'] == 'DiaSource':


### PR DESCRIPTION
Using getPackageDir means that the path is burned into the config on read but this leads to the config stored in quantum graphs having a hard coded path to the location of ap_association at that time. For some workflow systems the path to the software on the execution node is in a different place so this breaks everything. This change embeds the environment variable in the config and relies on the runtime to call expandvars.