### PR TITLE
DM-31220: Use new DiaPipelineTask API in ApPipeTask

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -322,6 +322,8 @@ class DiaPipelineTask(pipeBase.PipelineTask):
             Template exposure used to create diffIm.
         ccdExposureIdBits : `int`
             Number of bits used for a unique ``ccdVisitId``.
+        band : `str`
+            The band in which the new DiaSources were detected.
 
         Returns
         -------

--- a/python/lsst/ap/association/transformDiaSourceCatalog.py
+++ b/python/lsst/ap/association/transformDiaSourceCatalog.py
@@ -105,6 +105,9 @@ class TransformDiaSourceCatalogTask(TransformCatalogBaseTask):
     ConfigClass = TransformDiaSourceCatalogConfig
     _DefaultName = "transformDiaSourceCatalog"
     RunnerClass = pipeBase.ButlerInitializedTaskRunner
+    # Needed to create a valid TransformCatalogBaseTask, but unused
+    inputDataset = "deepDiff_diaSrc"
+    outputDataset = "deepDiff_diaSrcTable"
 
     def __init__(self, initInputs, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
This PR tweaks `TransformDiaSourceCatalogTask` so that `DiaPipelineTask` can be unit-tested in lsst/ap_pipe#86, and adds some missing documentation to `DiaPipelineTask`.