### PR TITLE
DM-28394: Remove workaround for hard-coded coord functors.

### DIFF
--- a/python/lsst/ap/association/transformDiaSourceCatalog.py
+++ b/python/lsst/ap/association/transformDiaSourceCatalog.py
@@ -195,11 +195,9 @@ class TransformDiaSourceCatalogTask(TransformCatalogBaseTask):
                             ParquetTable(dataFrame=diaSourceDf),
                             self.funcs,
                             dataId=None).df
-        # The Ra/DecColumn functors preserve the coord_ra/dec original columns.
-        # Since we don't need these and keeping them causes a DB insert crash
-        # we drop them from the DataFrame before returning output catalog.
+
         return pipeBase.Struct(
-            diaSourceTable=df.drop(columns=["coord_ra", "coord_dec"]),
+            diaSourceTable=df,
         )
 
     def computeBBoxSizes(self, inputCatalog):


### PR DESCRIPTION
Corresponds to the removal of the default Ra/DecColumn
functors from from PostprocessAnalysis.