### PR TITLE
DM-31825: Implement RFC-807 on DRP parquet table consistency

### DIFF
--- a/data/flag-rename-rules.yaml
+++ b/data/flag-rename-rules.yaml
@@ -1,0 +1,7 @@
+flag_rename_rules:
+    - ['base_PixelFlags_flag', 'pixelFlags']
+    - ['ip_diffim_forced_PsfFlux', 'forced_PsfFlux']
+    - ['slot_ApFlux', 'apFlux']
+    - ['slot_Centroid', 'centroid']
+    - ['slot_PsfFlux', 'psfFlux']
+    - ['slot_Shape', 'shape']

--- a/python/lsst/ap/association/transformDiaSourceCatalog.py
+++ b/python/lsst/ap/association/transformDiaSourceCatalog.py
@@ -32,7 +32,7 @@ from lsst.daf.base import DateTime
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as connTypes
-from lsst.pipe.tasks.postprocess import TransformCatalogBaseTask
+from lsst.pipe.tasks.postprocess import TransformCatalogBaseTask, TransformCatalogBaseConfig
 from lsst.pipe.tasks.parquetTable import ParquetTable
 from lsst.pipe.tasks.functors import Column
 
@@ -67,7 +67,7 @@ class TransformDiaSourceCatalogConnections(pipeBase.PipelineTaskConnections,
     )
 
 
-class TransformDiaSourceCatalogConfig(pipeBase.PipelineTaskConfig,
+class TransformDiaSourceCatalogConfig(TransformCatalogBaseConfig,
                                       pipelineConnections=TransformDiaSourceCatalogConnections):
     """
     """
@@ -85,14 +85,6 @@ class TransformDiaSourceCatalogConfig(pipeBase.PipelineTaskConfig,
                              "data",
                              "flag-rename-rules.yaml"),
     )
-    functorFile = pexConfig.Field(
-        dtype=str,
-        doc='Path to YAML file specifying Science DataModel functors to use '
-            'when copying columns and computing calibrated values.',
-        default=os.path.join("${AP_ASSOCIATION_DIR}",
-                             "data",
-                             "DiaSource.yaml")
-    )
     doRemoveSkySources = pexConfig.Field(
         dtype=bool,
         default=False,
@@ -105,6 +97,12 @@ class TransformDiaSourceCatalogConfig(pipeBase.PipelineTaskConfig,
         doc="Do pack the flags into one integer column named 'flags'."
             "If False, instead produce one boolean column per flag."
     )
+
+    def setDefaults(self):
+        super().setDefaults()
+        self.functorFile = os.path.join("${AP_ASSOCIATION_DIR}",
+                                        "data",
+                                        "DiaSource.yaml")
 
 
 class TransformDiaSourceCatalogTask(TransformCatalogBaseTask):


### PR DESCRIPTION
-  Adapt to parent class optional primaryKey config.
-  Inherit config from base task
-  Add config parameter to switch whether flags are transformed as one bit-packed column named 'flags' or individual boolean columns  with column rename rules applied.