### PR TITLE
DM-29955: Add ExposureInfo id getter

### DIFF
--- a/tests/test_diaForcedSource.py
+++ b/tests/test_diaForcedSource.py
@@ -122,6 +122,7 @@ class TestDiaForcedSource(unittest.TestCase):
             exposureTime=self.exposureTime,
             date=dafBase.DateTime(self.dateTime,
                                   dafBase.DateTime.Timescale.TAI))
+        self.exposure.info.id = self.exposureId
         self.exposure.setDetector(detector)
         self.exposure.getInfo().setVisitInfo(visit)
         self.exposure.setFilterLabel(afwImage.FilterLabel(band='g', physical='g.MP9401'))
@@ -138,6 +139,7 @@ class TestDiaForcedSource(unittest.TestCase):
                               self.imageSize[1]))
         masked_image = afwImage.MaskedImageF(source_image, bbox, afwImage.LOCAL)
         self.diffim = afwImage.makeExposure(masked_image, self.wcs)
+        self.diffim.info.id = self.exposureId
         self.diffim.setDetector(detector)
         self.diffim.getInfo().setVisitInfo(visit)
         self.diffim.setFilterLabel(afwImage.FilterLabel(band='g', physical='g.MP9401'))

--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -111,6 +111,7 @@ def makeExposure(flipX=False, flipY=False):
         exposureTime=200.,
         date=dafBase.DateTime("2014-05-13T17:00:00.000000000",
                               dafBase.DateTime.Timescale.TAI))
+    exposure.info.id = 1234
     exposure.setDetector(detector)
     exposure.getInfo().setVisitInfo(visit)
     exposure.setFilterLabel(afwImage.FilterLabel(band='g'))

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -273,6 +273,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
             exposureTime=200.,
             date=dafBase.DateTime("2014-05-13T17:00:00.000000000",
                                   dafBase.DateTime.Timescale.TAI))
+        self.exposure.info.id = 1234
         self.exposure.getInfo().setVisitInfo(visit)
 
         self.exposure.setFilterLabel(afwImage.FilterLabel(band='g', physical="g.MP9401"))

--- a/tests/test_transformDiaSourceCatalog.py
+++ b/tests/test_transformDiaSourceCatalog.py
@@ -63,6 +63,7 @@ class TestTransformDiaSourceCatalogTask(unittest.TestCase):
             exposureId=self.expId,
             exposureTime=200.,
             date=self.date)
+        self.exposure.info.id = self.expId
         self.exposure.setDetector(detector)
         self.exposure.getInfo().setVisitInfo(visit)
         self.filterName = 'g'


### PR DESCRIPTION
This PR uses the `id` component added on lsst/afw#613.