### PR TITLE
DM-32131: Remove unused tables from schema YAML file.

### DIFF
--- a/data/apdb-ap-pipe-schema-extra.yaml
+++ b/data/apdb-ap-pipe-schema-extra.yaml
@@ -571,40 +571,6 @@ columns:
   description: Name of stored filter.
 
 ---
-# DiaObjectLast uses the same columns as DiaObject but has different index
-table: DiaObjectLast
-indices:
-- name: PK_DiaObjectLast
-  columns:
-  - pixelId
-  - diaObjectId
-  type: PRIMARY
-- name: IDX_DiaObjectLast_diaObjectId
-  columns:
-  - diaObjectId
-  type: INDEX
-- name: nDiaSources
-  type: INT
-  nullable: false
-  description: Total number of DiaSources associated with this DiaObject.
-
----
-# Special PK index for DiaObject table with spacial column being first
-# (should provide better locality)
-table: DiaObjectIndexHtmFirst
-indices:
-- name: PK_DiaObject
-  columns:
-  - pixelId
-  - diaObjectId
-  - validityStart
-  type: PRIMARY
-- name: IDX_DiaObject_diaObjectId
-  columns:
-  - diaObjectId
-  type: INDEX
-
----
 # Added columns for DIASource table for use in ap_association.
 table: DiaSource
 columns:


### PR DESCRIPTION
Two tables removed are not used and one was incorrectly defined. Removed
them to avoid issues with unit tests.