### PR TITLE
DM-13943: Deprecate VisitInfo.getExposureId()

### DIFF
--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -124,7 +124,7 @@ class DiaForcedSourceTask(pipeBase.Task):
         afw_dia_objects = self._convert_from_pandas(dia_objects)
 
         idFactoryDiff = afwTable.IdFactory.makeSource(
-            diffim.getInfo().getVisitInfo().getExposureId(),
+            diffim.info.id,
             afwTable.IdFactory.computeReservedFromMaxBits(int(expIdBits)))
 
         diffForcedSources = self.forcedMeasurement.generateMeasCat(
@@ -230,7 +230,7 @@ class DiaForcedSourceTask(pipeBase.Task):
         output_catalog["totFluxErr"] = direct_fluxes[:, 1]
 
         visit_info = direct_exp.getInfo().getVisitInfo()
-        ccdVisitId = visit_info.getExposureId()
+        ccdVisitId = direct_exp.info.id
         midPointTaiMJD = visit_info.getDate().get(system=DateTime.MJD)
         output_catalog["ccdVisitId"] = ccdVisitId
         output_catalog["midPointTai"] = midPointTaiMJD

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -116,7 +116,7 @@ class PackageAlertsTask(pipeBase.Task):
         alerts = []
         self._patchDiaSources(diaSourceCat)
         self._patchDiaSources(diaSrcHistory)
-        ccdVisitId = diffIm.getInfo().getVisitInfo().getExposureId()
+        ccdVisitId = diffIm.info.id
         diffImPhotoCalib = diffIm.getPhotoCalib()
         templatePhotoCalib = template.getPhotoCalib()
         for srcIndex, diaSource in diaSourceCat.iterrows():

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -130,7 +130,7 @@ def makeDiaSources(nSources, diaObjectIds, exposure):
         system=dafBase.DateTime.MJD)
 
     wcs = exposure.getWcs()
-    ccdVisitId = exposure.getInfo().getVisitInfo().getExposureId()
+    ccdVisitId = exposure.info.id
 
     data = []
     for idx, (x, y) in enumerate(zip(rand_x, rand_y)):
@@ -177,7 +177,7 @@ def makeDiaForcedSources(nSources, diaObjectIds, exposure):
     midPointTaiMJD = exposure.getInfo().getVisitInfo().getDate().get(
         system=dafBase.DateTime.MJD)
 
-    ccdVisitId = exposure.getInfo().getVisitInfo().getExposureId()
+    ccdVisitId = exposure.info.id
 
     data = []
     for idx in range(nSources):
@@ -447,7 +447,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
                           self.exposure,
                           None)
 
-        ccdVisitId = self.exposure.getInfo().getVisitInfo().getExposureId()
+        ccdVisitId = self.exposure.info.id
         with open(os.path.join(tempdir, f"{ccdVisitId}.avro"), 'rb') as f:
             writer_schema, data_stream = \
                 packageAlerts.alertSchema.retrieve_alerts(f)


### PR DESCRIPTION
This PR removes uses of `VisitInfo.getExposureId()`, which was deprecated in lsst/afw#614.