### PR TITLE
DM-34363: Add trailFlux measurement to ap_association

### DIFF
--- a/data/DiaSource.yaml
+++ b/data/DiaSource.yaml
@@ -90,7 +90,13 @@ funcs:
     psNdata:
         functor: Column
         args: slot_PsfFlux_npixels
-    # trailFlux not implemented
+    trailFlux:
+        functor: LocalNanojansky
+        args:
+            - ext_trailedSources_Naive_flux
+            - slot_ApFlux_instFluxErr  # Place holder; arg not actually used
+            - base_LocalPhotoCalib
+            - base_LocalPhotoCalibErr
     trailRa:
         functor: Column
         args: ext_trailedSources_Naive_ra


### PR DESCRIPTION
Adds `trailFlux` to `DiaSources.yaml`.

Note: Flux error is not implemented yet, so a place-holder is given to the functor. That argument is not used in the transformation anyways.