### PR TITLE
DM-32694: Split AP pipeline into ApPipeWithFakes

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -78,7 +78,7 @@ class DiaPipelineConnections(
     exposure = connTypes.Input(
         doc="Calibrated exposure differenced with a template image during "
             "image differencing.",
-        name="calexp",
+        name="{fakesType}calexp",
         storageClass="ExposureF",
         dimensions=("instrument", "visit", "detector"),
     )


### PR DESCRIPTION
This PR changes `DiaPipelineTask` to use `fakes_calexp` when appropriate, consistent with other input datasets.