### PR TITLE
DM-33821: Update docstrings for solar system metrics.

### DIFF
--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -223,10 +223,11 @@ class NumberSolarSystemObjectsMetricTask(MetadataMetricTask):
             A `dict` representation of the metadata. Each `dict` has the
             following key:
 
-            ``"unassociatedObjects"``
-                The number of DIAObjects not associated with a DiaSource in
-                this image (`int` or `None`). May be `None` if the image was
-                not successfully associated.
+            ``"numTotalSolarSystemObjects"``
+                The number of SolarSystemObjects within the observable detector
+                area (`int` or `None`). May be `None` if solar system
+                association was not attempted or the image was not
+                successfully associated.
 
         Returns
         -------
@@ -272,10 +273,10 @@ class NumberAssociatedSolarSystemObjectsMetricTask(MetadataMetricTask):
             A `dict` representation of the metadata. Each `dict` has the
             following key:
 
-            ``"unassociatedObjects"``
-                The number of DIAObjects not associated with a DiaSource in
-                this image (`int` or `None`). May be `None` if the image was
-                not successfully associated.
+            ``"numAssociatedSsObjects"``
+                The number of successfully associated SolarSystem Objects
+                (`int` or `None`). May be `None` if solar system association
+                was not attempted or the image was not successfully associated.
 
         Returns
         -------

--- a/python/lsst/ap/association/skyBotEphemerisQuery.py
+++ b/python/lsst/ap/association/skyBotEphemerisQuery.py
@@ -119,9 +119,49 @@ class SkyBotEphemerisQueryTask(PipelineTask):
             Results struct with components:
 
             - ``ssObjects``: `pandas.DataFrame`
-                DataFrame containing name, RA/DEC position, position
-                uncertainty, and unique Id of on sky of Solar System Objects in
-                field of view as retrieved by SkyBot.
+                DataFrame containing Solar System Objects in field of view as
+                retrieved by SkyBot. The columns are as follows; for more
+                details see
+                https://ssp.imcce.fr/webservices/skybot/api/conesearch/#output-results
+
+                ``"Num"``
+                    object number (`int`, optional)
+                ``"Name"``
+                    object name (`str`)
+                ``"RA(h)"``
+                    RA in HMS (`str`)
+                ``"DE(deg)"``
+                    DEC in DMS (`str`)
+                ``"Class"``
+                    Minor planet classification (`str`)
+                ``"Mv"``
+                    visual magnitude (`float`)
+                ``"Err(arcsec)"``
+                    position error (`float`)
+                ``"d(arcsec)"``
+                    distance from exposure boresight (`float`)?
+                ``"dRA(arcsec/h)"``
+                    proper motion in RA (`float`)
+                ``"dDEC(arcsec/h)"``
+                    proper motion in DEC (`float`)
+                ``"Dg(ua)"``
+                    geocentric distance (`float`)
+                ``"Dh(ua)"``
+                    heliocentric distance (`float`)
+                ``"Phase(deg)"``
+                    phase angle (`float`)
+                ``"SunElong(deg)"``
+                    solar elongation (`float`)
+                ``"ra"``
+                    RA in decimal degrees (`float`)
+                ``"decl"``
+                    DEC in decimal degrees (`float`)
+                ``"ssObjectId"``
+                    unique minor planet ID for internal use (`int`). Shared
+                    across catalogs; the pair ``(ssObjectId, visitId)`` is
+                    globally unique.
+                ``"visitId"``
+                    a copy of ``visit`` (`int`)
         """
         # Grab the visitInfo from the raw to get the information needed on the
         # full visit.


### PR DESCRIPTION
This PR fixes some copy-pasted docstrings, borrowing text from the code that calculated the metadata in the first place. It also documents the ephemeris catalog format so that we know what information we have for future development.