### PR TITLE
DM-27177: Deprecate transitional getFilterLabel API

### DIFF
--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -234,7 +234,7 @@ class DiaForcedSourceTask(pipeBase.Task):
         midPointTaiMJD = visit_info.getDate().get(system=DateTime.MJD)
         output_catalog["ccdVisitId"] = ccdVisitId
         output_catalog["midPointTai"] = midPointTaiMJD
-        output_catalog["filterName"] = diff_exp.getFilterLabel().bandLabel
+        output_catalog["filterName"] = diff_exp.getFilter().bandLabel
 
         # Drop superfluous columns from output DataFrame.
         output_catalog.drop(columns=self.config.dropColumns, inplace=True)

--- a/tests/test_diaForcedSource.py
+++ b/tests/test_diaForcedSource.py
@@ -126,7 +126,7 @@ class TestDiaForcedSource(unittest.TestCase):
         self.exposure.info.id = self.exposureId
         self.exposure.setDetector(detector)
         self.exposure.getInfo().setVisitInfo(visit)
-        self.exposure.setFilterLabel(afwImage.FilterLabel(band='g', physical='g.MP9401'))
+        self.exposure.setFilter(afwImage.FilterLabel(band='g', physical='g.MP9401'))
         self.exposure.setPhotoCalib(afwImage.PhotoCalib(self.calibration, self.calibrationErr))
 
         # Difference Image
@@ -143,7 +143,7 @@ class TestDiaForcedSource(unittest.TestCase):
         self.diffim.info.id = self.exposureId
         self.diffim.setDetector(detector)
         self.diffim.getInfo().setVisitInfo(visit)
-        self.diffim.setFilterLabel(afwImage.FilterLabel(band='g', physical='g.MP9401'))
+        self.diffim.setFilter(afwImage.FilterLabel(band='g', physical='g.MP9401'))
         self.diffim.setPhotoCalib(afwImage.PhotoCalib(self.calibration, self.calibrationErr))
 
         self.expIdBits = 16

--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -114,7 +114,7 @@ def makeExposure(flipX=False, flipY=False):
     exposure.info.id = 1234
     exposure.setDetector(detector)
     exposure.getInfo().setVisitInfo(visit)
-    exposure.setFilterLabel(afwImage.FilterLabel(band='g'))
+    exposure.setFilter(afwImage.FilterLabel(band='g'))
 
     return exposure
 

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -148,7 +148,7 @@ def makeDiaSources(nSources, diaObjectIds, exposure):
                      "prv_procOrder": 0,
                      "diaSourceId": idx + 1,
                      "midPointTai": midPointTaiMJD + 1.0 * idx,
-                     "filterName": exposure.getFilterLabel().bandLabel,
+                     "filterName": exposure.getFilter().bandLabel,
                      "psNdata": 0,
                      "trailNdata": 0,
                      "dipNdata": 0,
@@ -187,7 +187,7 @@ def makeDiaForcedSources(nSources, diaObjectIds, exposure):
                      "ccdVisitId": ccdVisitId + idx,
                      "diaObjectId": objId,
                      "midPointTai": midPointTaiMJD + 1.0 * idx,
-                     "filterName": exposure.getFilterLabel().bandLabel,
+                     "filterName": exposure.getFilter().bandLabel,
                      "flags": 0})
 
     return pd.DataFrame(data=data)
@@ -272,7 +272,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
         self.exposure.info.id = 1234
         self.exposure.getInfo().setVisitInfo(visit)
 
-        self.exposure.setFilterLabel(afwImage.FilterLabel(band='g', physical="g.MP9401"))
+        self.exposure.setFilter(afwImage.FilterLabel(band='g', physical="g.MP9401"))
 
         diaObjects = makeDiaObjects(2, self.exposure)
         diaSourceHistory = makeDiaSources(10,

--- a/tests/test_transformDiaSourceCatalog.py
+++ b/tests/test_transformDiaSourceCatalog.py
@@ -67,7 +67,7 @@ class TestTransformDiaSourceCatalogTask(unittest.TestCase):
         self.exposure.setDetector(detector)
         self.exposure.getInfo().setVisitInfo(visit)
         self.filterName = 'g'
-        self.exposure.setFilterLabel(afwImage.FilterLabel(band=self.filterName, physical='g.MP9401'))
+        self.exposure.setFilter(afwImage.FilterLabel(band=self.filterName, physical='g.MP9401'))
         scale = 2
         scaleErr = 1
         self.photoCalib = afwImage.PhotoCalib(scale, scaleErr)


### PR DESCRIPTION
This PR removes references to `getFilterLabel` and similarly-named methods, replacing them with `getFilter` (etc.) methods backed by `FilterLabel`.