### PR TITLE
DM-35331: Add note about int requirement, and restore np.empty

### DIFF
--- a/python/lsst/ap/association/transformDiaSourceCatalog.py
+++ b/python/lsst/ap/association/transformDiaSourceCatalog.py
@@ -259,7 +259,8 @@ class TransformDiaSourceCatalogTask(TransformCatalogBaseTask):
         outputBBoxSizes : `np.ndarray`, (N,)
             Array of bbox sizes.
         """
-        outputBBoxSizes = np.zeros(len(inputCatalog), dtype=int)
+        # Schema validation requires that this field is int.
+        outputBBoxSizes = np.empty(len(inputCatalog), dtype=int)
         for i, record in enumerate(inputCatalog):
             footprintBBox = record.getFootprint().getBBox()
             # Compute twice the size of the largest dimension of the footprint


### PR DESCRIPTION
I'm restoring the use of `empty` here because that was an intentional choice (all the fields will get initialized in the loop), and it's good to have a note as to why that `int` really is necessary.