### PR TITLE
DM-33256: Remove Gen 2 support from verify

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,5 @@
-Copyright 2017-2019 University of Washington
+Copyright 2017-2022 University of Washington
+Copyright 2021 University of Illinois Board of Trustees
+Copyright 2019-2022 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
+Copyright 2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2021 The Trustees of Princeton University

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask.rst
@@ -32,8 +32,7 @@ Input datasets
 --------------
 
 :lsst-config-field:`~lsst.verify.tasks.metadataMetricTask.MetadataMetricConfig.metadata`
-    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
-    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``FractionUpdatedDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+    The metadata of the top-level pipeline task (e.g., ``CharacterizeImageTask``, ``DiaPipeTask``) being instrumented.
 
 .. _lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask-subtasks:
 

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask.rst
@@ -31,8 +31,7 @@ Input datasets
 --------------
 
 :lsst-config-field:`~lsst.verify.tasks.metadataMetricTask.MetadataMetricConfig.metadata`
-    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
-    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``NumberNewDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+    The metadata of the top-level pipeline task (e.g., ``CharacterizeImageTask``, ``DiaPipeTask``) being instrumented.
 
 .. _lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask-subtasks:
 

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask.rst
@@ -32,8 +32,7 @@ Input datasets
 --------------
 
 :lsst-config-field:`~lsst.verify.tasks.metadataMetricTask.MetadataMetricConfig.metadata`
-    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
-    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``NumberUnassociatedDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+    The metadata of the top-level pipeline task (e.g., ``CharacterizeImageTask``, ``DiaPipeTask``) being instrumented.
 
 .. _lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask-subtasks:
 

--- a/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask.rst
+++ b/doc/lsst.ap.association/tasks/lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask.rst
@@ -32,7 +32,6 @@ Input datasets
 :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbInfo`
     The Butler dataset from which the database connection can be initialized.
     The type must match the input required by the :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbLoader` subtask (default: the top-level science task's config).
-    If the input is a config, its name **must** be explicitly configured when running ``TotalUnassociatedDiaObjectsMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
 
 .. _lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask-subtasks:
 

--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -32,7 +32,6 @@ __all__ = ["NumberNewDiaObjectsMetricTask",
 import astropy.units as u
 
 from lsst.verify import Measurement
-from lsst.verify.gen2tasks import register
 from lsst.verify.tasks import MetadataMetricTask, MetadataMetricConfig, \
     ApdbMetricTask, ApdbMetricConfig, MetricComputationError
 
@@ -43,7 +42,6 @@ class NumberNewDiaObjectsMetricConfig(MetadataMetricConfig):
         self.connections.metric = "numNewDiaObjects"
 
 
-@register("numNewDiaObjects")
 class NumberNewDiaObjectsMetricTask(MetadataMetricTask):
     """Task that computes the number of DIASources that create new DIAObjects
     in an image, visit, etc..
@@ -92,7 +90,6 @@ class NumberUnassociatedDiaObjectsMetricConfig(MetadataMetricConfig):
         self.connections.metric = "numUnassociatedDiaObjects"
 
 
-@register("numUnassociatedDiaObjects")
 class NumberUnassociatedDiaObjectsMetricTask(MetadataMetricTask):
     """Task that computes the number of previously-known DIAObjects that do
     not have detected DIASources in an image, visit, etc..
@@ -141,7 +138,6 @@ class FractionUpdatedDiaObjectsMetricConfig(MetadataMetricConfig):
         self.connections.metric = "fracUpdatedDiaObjects"
 
 
-@register("fracUpdatedDiaObjects")
 class FractionUpdatedDiaObjectsMetricTask(MetadataMetricTask):
     """Task that computes the fraction of previously created DIAObjects that
     have a new association in this image, visit, etc..
@@ -205,7 +201,6 @@ class NumberSolarSystemObjectsMetricConfig(MetadataMetricConfig):
         self.connections.metric = "numTotalSolarSystemObjects"
 
 
-@register("numTotalSolarSystemObjects")
 class NumberSolarSystemObjectsMetricTask(MetadataMetricTask):
     """Task that computes the number of SolarSystemObjects that are
     observable within this detectorVisit.
@@ -256,7 +251,6 @@ class NumberAssociatedSolarSystemObjectsMetricConfig(MetadataMetricConfig):
         self.connections.metric = "numAssociatedSsObjects"
 
 
-@register("numAssociatedSsObjects")
 class NumberAssociatedSolarSystemObjectsMetricTask(MetadataMetricTask):
     """Number of SolarSystemObjects that were associated with new DiaSources
     for this detectorVisit.
@@ -305,7 +299,6 @@ class TotalUnassociatedDiaObjectsMetricConfig(ApdbMetricConfig):
         self.connections.metric = "totalUnassociatedDiaObjects"
 
 
-@register("totalUnassociatedDiaObjects")
 class TotalUnassociatedDiaObjectsMetricTask(ApdbMetricTask):
     """Task that computes the number of DIAObjects with only one
     associated DIASource.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -31,9 +31,8 @@ from lsst.dax.apdb import Apdb
 from lsst.pipe.base import Task, Struct
 import lsst.pipe.base.testUtils
 from lsst.verify import Name
-from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
 from lsst.verify.tasks import MetricComputationError
-from lsst.verify.tasks.testUtils import MetadataMetricTestCase, ApdbMetricTestCase
+from lsst.verify.tasks.testUtils import MetricTaskTestCase, MetadataMetricTestCase, ApdbMetricTestCase
 
 from lsst.ap.association.metrics import \
     NumberNewDiaObjectsMetricTask, \


### PR DESCRIPTION
This PR removes use of the `lsst.verify.gen2tasks.register` decorator as well as all references to `lsst.verify.gen2tasks.MetricsControllerTask`. Both are removed in lsst/verify#103.