### PR TITLE
DM-30869: Modernize MetricTask for better Gen 3 workflow

### DIFF
--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -31,6 +31,7 @@ __all__ = ["NumberNewDiaObjectsMetricTask",
 
 import astropy.units as u
 
+from lsst.pipe.base import NoWorkFound
 from lsst.verify import Measurement
 from lsst.verify.tasks import MetadataMetricTask, MetadataMetricConfig, \
     ApdbMetricTask, ApdbMetricConfig, MetricComputationError
@@ -76,8 +77,7 @@ class NumberNewDiaObjectsMetricTask(MetadataMetricTask):
             else:
                 return Measurement(self.config.metricName, nNew * u.count)
         else:
-            self.log.info("Nothing to do: no association results found.")
-            return None
+            raise NoWorkFound("Nothing to do: no association results found.")
 
     @classmethod
     def getInputMetadataKeys(cls, config):
@@ -124,8 +124,7 @@ class NumberUnassociatedDiaObjectsMetricTask(MetadataMetricTask):
             else:
                 return Measurement(self.config.metricName, nNew * u.count)
         else:
-            self.log.info("Nothing to do: no association results found.")
-            return None
+            raise NoWorkFound("Nothing to do: no association results found.")
 
     @classmethod
     def getInputMetadataKeys(cls, config):
@@ -186,8 +185,7 @@ class FractionUpdatedDiaObjectsMetricTask(MetadataMetricTask):
                     fraction = nUpdated / (nUpdated + nUnassociated)
                     return Measurement(self.config.metricName, fraction * u.dimensionless_unscaled)
         else:
-            self.log.info("Nothing to do: no association results found.")
-            return None
+            raise NoWorkFound("Nothing to do: no association results found.")
 
     @classmethod
     def getInputMetadataKeys(cls, config):
@@ -237,8 +235,7 @@ class NumberSolarSystemObjectsMetricTask(MetadataMetricTask):
             else:
                 return Measurement(self.config.metricName, nNew * u.count)
         else:
-            self.log.info("Nothing to do: no solar system results found.")
-            return None
+            raise NoWorkFound("Nothing to do: no solar system results found.")
 
     @classmethod
     def getInputMetadataKeys(cls, config):
@@ -285,8 +282,7 @@ class NumberAssociatedSolarSystemObjectsMetricTask(MetadataMetricTask):
             else:
                 return Measurement(self.config.metricName, nNew * u.count)
         else:
-            self.log.info("Nothing to do: no solar system results found.")
-            return None
+            raise NoWorkFound("Nothing to do: no solar system results found.")
 
     @classmethod
     def getInputMetadataKeys(cls, config):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,10 +78,16 @@ class TestNewDiaObjects(MetadataMetricTestCase):
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
     def testAssociationFailed(self):
-        result = self.task.run(PropertySet())
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = self.task.run(PropertySet())
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testBadlyTypedKeys(self):
         metadata = _makeAssociationMetadata()
@@ -117,10 +123,16 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
     def testAssociationFailed(self):
-        result = self.task.run(PropertySet())
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = self.task.run(PropertySet())
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testBadlyTypedKeys(self):
         metadata = _makeAssociationMetadata()
@@ -167,18 +179,28 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
     def testNoObjects(self):
         metadata = _makeAssociationMetadata(numUpdated=0, numUnassociated=0)
-        result = self.task.run(metadata)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-
-        self.assertIsNone(meas)
-
+        try:
+            result = self.task.run(metadata)
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testAssociationFailed(self):
-        result = self.task.run(PropertySet())
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = self.task.run(PropertySet())
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testBadlyTypedKeys(self):
         metadata = _makeAssociationMetadata()
@@ -214,10 +236,16 @@ class TestNumberSolarSystemObjects(MetadataMetricTestCase):
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
     def testAssociationFailed(self):
-        result = self.task.run(PropertySet())
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = self.task.run(PropertySet())
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testBadlyTypedKeys(self):
         metadata = _makeAssociationMetadata()
@@ -253,10 +281,16 @@ class TestNumberAssociatedSolarSystemObjects(MetadataMetricTestCase):
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
     def testAssociationFailed(self):
-        result = self.task.run(PropertySet())
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = self.task.run(PropertySet())
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testBadlyTypedKeys(self):
         metadata = _makeAssociationMetadata()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -77,12 +77,6 @@ class TestNewDiaObjects(MetadataMetricTestCase):
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numNewDiaObjects"))
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
-
     def testAssociationFailed(self):
         result = self.task.run(PropertySet())
         lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
@@ -121,12 +115,6 @@ class TestUnassociatedDiaObjects(MetadataMetricTestCase):
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numUnassociatedDiaObjects"))
         self.assertEqual(meas.quantity, 0.0 * u.count)
-
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
 
     def testAssociationFailed(self):
         result = self.task.run(PropertySet())
@@ -185,11 +173,6 @@ class TestFracUpdatedDiaObjects(MetadataMetricTestCase):
 
         self.assertIsNone(meas)
 
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
 
     def testAssociationFailed(self):
         result = self.task.run(PropertySet())
@@ -230,12 +213,6 @@ class TestNumberSolarSystemObjects(MetadataMetricTestCase):
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numTotalSolarSystemObjects"))
         self.assertEqual(meas.quantity, 0.0 * u.count)
 
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
-
     def testAssociationFailed(self):
         result = self.task.run(PropertySet())
         lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
@@ -274,12 +251,6 @@ class TestNumberAssociatedSolarSystemObjects(MetadataMetricTestCase):
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.numAssociatedSsObjects"))
         self.assertEqual(meas.quantity, 0.0 * u.count)
-
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
 
     def testAssociationFailed(self):
         result = self.task.run(PropertySet())
@@ -349,12 +320,6 @@ class TestTotalUnassociatedObjects(ApdbMetricTestCase):
 
         self.assertEqual(meas.metric_name, Name(metric="ap_association.totalUnassociatedDiaObjects"))
         self.assertEqual(meas.quantity, 0.0 * u.count)
-
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
 
     def testFineGrainedMetric(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR removes all code for handling `None` inputs from concrete `MetricTasks` and raises `NoWorkFound` where appropriate.