### PR TITLE
DM-36058: Fix untested Pandas deprecation warnings in ap_association

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -383,8 +383,9 @@ class DiaPipelineTask(pipeBase.PipelineTask):
                                        inplace=True)
 
         # Append new DiaObjects and DiaSources to their previous history.
-        diaObjects = loaderResult.diaObjects.append(
-            createResults.newDiaObjects.set_index("diaObjectId", drop=False),
+        diaObjects = pd.concat(
+            [loaderResult.diaObjects,
+             createResults.newDiaObjects.set_index("diaObjectId", drop=False)],
             sort=True)
         if self.testDataFrameIndex(diaObjects):
             raise RuntimeError(
@@ -393,8 +394,8 @@ class DiaPipelineTask(pipeBase.PipelineTask):
                 "Apdb. If this was not the case then there was an unexpected "
                 "failure in Association while matching and creating new "
                 "DiaObjects and should be reported. Exiting.")
-        mergedDiaSourceHistory = loaderResult.diaSources.append(
-            associatedDiaSources,
+        mergedDiaSourceHistory = pd.concat(
+            [loaderResult.diaSources, associatedDiaSources],
             sort=True)
         # Test for DiaSource duplication first. If duplicates are found,
         # this likely means this is duplicate data being processed and sent
@@ -445,8 +446,8 @@ class DiaPipelineTask(pipeBase.PipelineTask):
 
         if self.config.doPackageAlerts:
             if len(loaderResult.diaForcedSources) > 1:
-                diaForcedSources = diaForcedSources.append(
-                    loaderResult.diaForcedSources,
+                diaForcedSources = pd.concat(
+                    [diaForcedSources, loaderResult.diaForcedSources],
                     sort=True)
             if self.testDataFrameIndex(diaForcedSources):
                 self.log.warning(

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -108,7 +108,7 @@ class TestDiaPipelineTask(unittest.TestCase):
         if not doSolarSystemAssociation:
             self.assertFalse(hasattr(task, "solarSystemAssociator"))
 
-        def concatMock(data):
+        def concatMock(_data, **_kwargs):
             return MagicMock(spec=pd.DataFrame)
 
         # Mock out the run() methods of these two Tasks to ensure they


### PR DESCRIPTION
This PR removes references to `Dataset.append` that weren't covered by unit tests, and tweaks the tests so that they don't make assumptions about the call signatures in application code. It does not try to expand test coverage to perform actual Pandas operations, since I don't see a way to introduce mock tables without making them brittle to external changes.