### PR TITLE
DM-40032: Add stacklevel parameter to the warnings

### DIFF
--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -135,6 +135,7 @@ class DiaForcedSourceTask(pipeBase.Task):
             warnings.warn(
                 "'expIdBits' argument is deprecated in favor of 'idGenerator'; will be removed after v26.",
                 category=FutureWarning,
+                stacklevel=3,  # Caller + timeMethod
             )
 
         if idGenerator is None:

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -119,6 +119,7 @@ class PackageAlertsTask(pipeBase.Task):
             warnings.warn(
                 "The 'ccdExposureIdBits' argument is deprecated and unused; it will be removed after v26.",
                 category=FutureWarning,
+                stacklevel=3,  # Caller + timeMethod
             )
         alerts = []
         self._patchDiaSources(diaSourceCat)


### PR DESCRIPTION
This makes them come from the code that called the run method with expIdBits.