### PR TITLE
DM-40412: Add edge flag filtering to trailedSourceFilter.py

### DIFF
--- a/data/association-flag-map.yaml
+++ b/data/association-flag-map.yaml
@@ -88,3 +88,6 @@ columns:
     - name: slot_Shape_flag_parent_source
       bit: 26
       doc: parent source, ignored; only valid for HsmShape
+    - name: ext_trailedSources_Naive_flag_edge
+      bit: 27
+      doc: source is trailed and extends off chip

--- a/python/lsst/ap/association/trailedSourceFilter.py
+++ b/python/lsst/ap/association/trailedSourceFilter.py
@@ -77,11 +77,11 @@ class TrailedSourceFilterTask(pipeBase.Task):
         result : `lsst.pipe.base.Struct`
             Results struct with components.
 
-            - ``dia_sources`` : DIASource table that is free from unwanted
+            - ``diaSources`` : DIASource table that is free from unwanted
              trailed sources. (`pandas.DataFrame`)
 
-            - ``trailed_dia_sources`` : DIASources that have trails which
-            exceed max_trail_length/second*exposure_time.
+            - ``longTrailedDiaSources`` : DIASources that have trails which
+            exceed max_trail_length/second*exposure_time (seconds).
             (`pandas.DataFrame`)
         """
 
@@ -93,14 +93,14 @@ class TrailedSourceFilterTask(pipeBase.Task):
 
         return pipeBase.Struct(
             diaSources=dia_sources[~trail_mask].reset_index(drop=True),
-            trailedDiaSources=dia_sources[trail_mask].reset_index(drop=True))
+            longTrailedDiaSources=dia_sources[trail_mask].reset_index(drop=True))
 
     def _check_dia_source_trail(self, dia_sources, exposure_time, flags):
         """Find DiaSources that have long trails.
 
         Return a mask of sources with lengths greater than
-        ``config.max_trail_length``  multiplied by the exposure time and
-        have ext_trailedSources_Naive_flag_edge set.
+        ``config.max_trail_length``  multiplied by the exposure time in seconds
+        or have ext_trailedSources_Naive_flag_edge set.
 
         Parameters
         ----------

--- a/python/lsst/ap/association/trailedSourceFilter.py
+++ b/python/lsst/ap/association/trailedSourceFilter.py
@@ -21,9 +21,14 @@
 
 __all__ = ("TrailedSourceFilterTask", "TrailedSourceFilterConfig")
 
+import os
+import numpy as np
+
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.utils.timer import timeMethod
+from lsst.ap.association.transformDiaSourceCatalog import UnpackApdbFlags
+import lsst.utils as utils
 
 
 class TrailedSourceFilterConfig(pexConfig.Config):
@@ -79,17 +84,23 @@ class TrailedSourceFilterTask(pipeBase.Task):
             exceed max_trail_length/second*exposure_time.
             (`pandas.DataFrame`)
         """
-        trail_mask = self._check_dia_source_trail(dia_sources, exposure_time)
+
+        flag_map = os.path.join(utils.getPackageDir("ap_association"), "data/association-flag-map.yaml")
+        unpacker = UnpackApdbFlags(flag_map, "DiaSource")
+        flags = unpacker.unpack(dia_sources["flags"], "flags")
+
+        trail_mask = self._check_dia_source_trail(dia_sources, exposure_time, flags)
 
         return pipeBase.Struct(
             diaSources=dia_sources[~trail_mask].reset_index(drop=True),
             trailedDiaSources=dia_sources[trail_mask].reset_index(drop=True))
 
-    def _check_dia_source_trail(self, dia_sources, exposure_time):
+    def _check_dia_source_trail(self, dia_sources, exposure_time, flags):
         """Find DiaSources that have long trails.
 
         Return a mask of sources with lengths greater than
-        ``config.max_trail_length``  multiplied by the exposure time.
+        ``config.max_trail_length``  multiplied by the exposure time and
+        have ext_trailedSources_Naive_flag_edge set.
 
         Parameters
         ----------
@@ -97,14 +108,18 @@ class TrailedSourceFilterTask(pipeBase.Task):
             Input DIASources to check for trail lengths.
         exposure_time : `float`
             Exposure time from difference image.
+        flags : 'numpy.ndArray'
+            Boolean array of flags from the DIASources.
 
         Returns
         -------
         trail_mask : `pandas.DataFrame`
             Boolean mask for DIASources which are greater than the
-            cutoff length.
+            cutoff length and have the edge flag set.
         """
         trail_mask = (dia_sources.loc[:, "trailLength"].values[:]
                       >= (self.config.max_trail_length*exposure_time))
+
+        trail_mask[np.where(flags['ext_trailedSources_Naive_flag_edge'])] = True
 
         return trail_mask

--- a/tests/test_association_task.py
+++ b/tests/test_association_task.py
@@ -22,9 +22,9 @@
 import numpy as np
 import pandas as pd
 import unittest
+
 import lsst.geom as geom
 import lsst.utils.tests
-
 from lsst.ap.association import AssociationTask
 
 
@@ -45,12 +45,14 @@ class TestAssociationTask(unittest.TestCase):
         self.diaSources = pd.DataFrame(data=[
             {"ra": 0.04*idx + scatter*rng.uniform(-1, 1),
              "dec": 0.04*idx + scatter*rng.uniform(-1, 1),
-             "diaSourceId": idx + 1 + self.nObjects, "diaObjectId": 0, "trailLength": 5.5*idx}
+             "diaSourceId": idx + 1 + self.nObjects, "diaObjectId": 0, "trailLength": 5.5*idx,
+             "flags": 0}
             for idx in range(self.nSources)])
         self.diaSourceZeroScatter = pd.DataFrame(data=[
             {"ra": 0.04*idx,
              "dec": 0.04*idx,
-             "diaSourceId": idx + 1 + self.nObjects, "diaObjectId": 0, "trailLength": 5.5*idx}
+             "diaSourceId": idx + 1 + self.nObjects, "diaObjectId": 0, "trailLength": 5.5*idx,
+             "flags": 0}
             for idx in range(self.nSources)])
         self.exposure_time = 30.0
 


### PR DESCRIPTION
Now that trailed sources which cross over into edge regions are flagged, add in a filter to trailedSourceFilter.py. Currently, this filter is far more aggressive than it should be as it counts trailed sources crossing over into nodata regions as edges. This will be fixed in a later commit.