### PR TITLE
DM-32769: Implement streak detection and masking in single frame processing

### DIFF
--- a/data/association-flag-map.yaml
+++ b/data/association-flag-map.yaml
@@ -91,3 +91,9 @@ columns:
     - name: ext_trailedSources_Naive_flag_edge
       bit: 27
       doc: source is trailed and extends off chip
+    - name: base_PixelFlags_flag_streak
+      bit: 28
+      doc: Streak in the Source footprint
+    - name: base_PixelFlags_flag_streakCenter
+      bit: 29
+      doc: Streak in the Source center


### PR DESCRIPTION
This PR adds two flags to the flag map. One is so the new streak mask info makes it into `associatedDiaSources`. The other is for backwards compatibility with DM-40412.