### PR TITLE
DM-34340: Adapt to daf_butler API changes.

### DIFF
--- a/python/lsst/ap/association/metrics.py
+++ b/python/lsst/ap/association/metrics.py
@@ -326,8 +326,10 @@ class TotalUnassociatedDiaObjectsMetricTask(ApdbMetricTask):
         ValueError
             Raised if outputDataId is not empty
         """
-        # All data ID types define keys()
-        if outputDataId.keys() - {'instrument'}:
+        # DataCoordinate objects are not mappings, so they don't have keys(),
+        # but their .required attribute is a mapping.
+        mapping = getattr(outputDataId, "required", outputDataId)
+        if mapping.keys() - {'instrument'}:
             raise ValueError("%s must not be associated with specific data IDs (gave %s)."
                              % (self.config.metricName, outputDataId))
 


### PR DESCRIPTION
I'm a little surprised the previous code ever worked with DataCoordinate objects - while they used to have keys(), it returned a set of Dimension instance, not strings.  I assume it did because Dimension.__eq__ accepts strings, but it isn't obvious that should translate into mixed-typed set differences working.