### PR TITLE
DM-42489: Update tests for changes in Apdb.makeSchema interface

### DIFF
--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -26,7 +26,7 @@ import unittest
 import yaml
 
 from lsst.ap.association import LoadDiaCatalogsTask, LoadDiaCatalogsConfig
-from lsst.dax.apdb import ApdbSql, ApdbSqlConfig, ApdbTables
+from lsst.dax.apdb import Apdb, ApdbSql, ApdbSqlConfig, ApdbTables
 from lsst.utils import getPackageDir
 import lsst.utils.tests
 from utils_tests import makeExposure, makeDiaObjects, makeDiaSources, makeDiaForcedSources
@@ -64,8 +64,8 @@ class TestLoadDiaCatalogs(unittest.TestCase):
         self.apdbConfig.dia_object_index = "baseline"
         self.apdbConfig.dia_object_columns = []
 
+        Apdb.makeSchema(self.apdbConfig)
         self.apdb = ApdbSql(config=self.apdbConfig)
-        self.apdb.makeSchema()
 
         self.exposure = makeExposure(False, False)
 

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -34,7 +34,7 @@ from lsst.ap.association import PackageAlertsConfig, PackageAlertsTask
 from lsst.afw.cameraGeom.testUtils import DetectorWrapper
 import lsst.afw.image as afwImage
 import lsst.daf.base as dafBase
-from lsst.dax.apdb import ApdbSql, ApdbSqlConfig
+from lsst.dax.apdb import Apdb, ApdbSql, ApdbSqlConfig
 import lsst.geom as geom
 import lsst.meas.base.tests
 from lsst.sphgeom import Box
@@ -71,8 +71,8 @@ def _roundTripThroughApdb(objects, sources, forcedSources, dateTime):
     apdbConfig.dia_object_index = "baseline"
     apdbConfig.dia_object_columns = []
 
+    Apdb.makeSchema(apdbConfig)
     apdb = ApdbSql(config=apdbConfig)
-    apdb.makeSchema()
 
     wholeSky = Box.full()
     diaObjects = pd.concat([apdb.getDiaObjects(wholeSky), objects])


### PR DESCRIPTION
The `makeSchema` method is now a class method instead of instance method and it takes configuration object as a parameter.