### PR TITLE
DM-41108: Do write associated sources by default

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -261,7 +261,7 @@ class DiaPipelineConfig(pipeBase.PipelineTaskConfig,
     )
     doWriteAssociatedSources = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc="Write out associated DiaSources, DiaForcedSources, and DiaObjects, "
             "formatted following the Science Data Model.",
     )


### PR DESCRIPTION
Change default of `doWriteAssociatedSources` to True