### PR TITLE
DM-43414: Update unit tests for changes in APDB API

### DIFF
--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -26,7 +26,7 @@ import unittest
 import yaml
 
 from lsst.ap.association import LoadDiaCatalogsTask, LoadDiaCatalogsConfig
-from lsst.dax.apdb import Apdb, ApdbSql, ApdbSqlConfig, ApdbTables
+from lsst.dax.apdb import Apdb, ApdbSql, ApdbTables
 from lsst.utils import getPackageDir
 import lsst.utils.tests
 from utils_tests import makeExposure, makeDiaObjects, makeDiaSources, makeDiaForcedSources
@@ -59,13 +59,8 @@ class TestLoadDiaCatalogs(unittest.TestCase):
         self.db_file_fd, self.db_file = tempfile.mkstemp(
             dir=os.path.dirname(__file__))
 
-        self.apdbConfig = ApdbSqlConfig()
-        self.apdbConfig.db_url = "sqlite:///" + self.db_file
-        self.apdbConfig.dia_object_index = "baseline"
-        self.apdbConfig.dia_object_columns = []
-
-        Apdb.makeSchema(self.apdbConfig)
-        self.apdb = ApdbSql(config=self.apdbConfig)
+        self.apdbConfig = ApdbSql.init_database(db_url="sqlite:///" + self.db_file)
+        self.apdb = Apdb.from_config(self.apdbConfig)
 
         self.exposure = makeExposure(False, False)
 

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -42,7 +42,7 @@ from lsst.ap.association import PackageAlertsConfig, PackageAlertsTask
 from lsst.afw.cameraGeom.testUtils import DetectorWrapper
 import lsst.afw.image as afwImage
 import lsst.daf.base as dafBase
-from lsst.dax.apdb import Apdb, ApdbSql, ApdbSqlConfig
+from lsst.dax.apdb import Apdb, ApdbSql
 import lsst.geom as geom
 import lsst.meas.base.tests
 from lsst.sphgeom import Box
@@ -74,13 +74,8 @@ def _roundTripThroughApdb(objects, sources, forcedSources, dateTime):
     """
     tmpFile = tempfile.NamedTemporaryFile()
 
-    apdbConfig = ApdbSqlConfig()
-    apdbConfig.db_url = "sqlite:///" + tmpFile.name
-    apdbConfig.dia_object_index = "baseline"
-    apdbConfig.dia_object_columns = []
-
-    Apdb.makeSchema(apdbConfig)
-    apdb = ApdbSql(config=apdbConfig)
+    apdbConfig = ApdbSql.init_database(db_url="sqlite:///" + tmpFile.name)
+    apdb = Apdb.from_config(apdbConfig)
 
     wholeSky = Box.full()
     diaObjects = pd.concat([apdb.getDiaObjects(wholeSky), objects])


### PR DESCRIPTION
APDB initialization is now done via special class method `init_database`, test cases in this package are updated to use new API.