### PR TITLE
DM-43522:Remove too large alert packet write to disk

### DIFF
--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -84,8 +84,8 @@ class PackageAlertsConfig(pexConfig.Config):
 
     doWriteFailedAlerts = pexConfig.Field(
         dtype=bool,
-        doc="If an alert cannot be sent when doProduceAlerts is set,"
-            " write it to disk for debugging purposes.",
+        doc="If an alert cannot be sent when doProduceAlerts is set, "
+            "write it to disk for debugging purposes.",
         default=False,
     )
 

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -84,7 +84,8 @@ class PackageAlertsConfig(pexConfig.Config):
 
     doWriteFailedAlerts = pexConfig.Field(
         dtype=bool,
-        doc="Write alerts which fail to send to disk for debugging purposes.",
+        doc="If an alert cannot be sent when doProduceAlerts is set,"
+            " write it to disk for debugging purposes.",
         default=False,
     )
 

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -440,7 +440,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
             else:
                 return
 
-        packConfig = PackageAlertsConfig(doProduceAlerts=True)
+        packConfig = PackageAlertsConfig(doProduceAlerts=True, doWriteFailedAlerts=True)
         packageAlerts = PackageAlertsTask(config=packConfig)
 
         patcher = patch("builtins.open")


### PR DESCRIPTION
As writing failed alerts to disk is only used for debugging, it should not be on by default and instead a configuration should be set when we want to inspect the alerts.