### PR TITLE
DM-43509: Switch to astropy.time in calls to Apdb methods

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -529,7 +529,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
         # Store DiaSources, updated DiaObjects, and DiaForcedSources in the
         # Apdb.
         self.apdb.store(
-            DateTime.now(),
+            DateTime.now().toAstropy(),
             diaCalResult.updatedDiaObjects,
             associatedDiaSources,
             diaForcedSources)

--- a/python/lsst/ap/association/loadDiaCatalogs.py
+++ b/python/lsst/ap/association/loadDiaCatalogs.py
@@ -183,7 +183,7 @@ class LoadDiaCatalogsTask(pipeBase.Task):
                                                "band",
                                                "diaSourceId"])
         else:
-            diaSources = apdb.getDiaSources(region, diaObjects.loc[:, "diaObjectId"], dateTime)
+            diaSources = apdb.getDiaSources(region, diaObjects.loc[:, "diaObjectId"], dateTime.toAstropy())
 
         diaSources.set_index(["diaObjectId", "band", "diaSourceId"],
                              drop=False,
@@ -231,7 +231,7 @@ class LoadDiaCatalogsTask(pipeBase.Task):
             diaForcedSources = apdb.getDiaForcedSources(
                 region,
                 diaObjects.loc[:, "diaObjectId"],
-                dateTime)
+                dateTime.toAstropy())
 
         diaForcedSources.set_index(["diaObjectId", "diaForcedSourceId"],
                                    drop=False,

--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -80,7 +80,7 @@ class TestLoadDiaCatalogs(unittest.TestCase):
             self.exposure)
 
         self.dateTime = self.exposure.visitInfo.date
-        self.apdb.store(self.dateTime,
+        self.apdb.store(self.dateTime.toAstropy(),
                         self.diaObjects,
                         self.diaSources,
                         self.diaForcedSources)

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -62,7 +62,7 @@ def _roundTripThroughApdb(objects, sources, forcedSources, dateTime):
         Set of test DiaSources to round trip.
     forcedSources : `pandas.DataFrame`
         Set of test DiaForcedSources to round trip.
-    dateTime : `lsst.daf.base.DateTime`
+    dateTime : `astropy.time.Time`
         Time for the Apdb.
 
     Returns
@@ -200,7 +200,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
             diaObjects,
             diaSourceHistory,
             diaForcedSources,
-            self.exposure.visitInfo.date)
+            self.exposure.visitInfo.date.toAstropy())
         self.diaObjects.replace(to_replace=[None], value=np.nan, inplace=True)
         diaSourceHistory.replace(to_replace=[None], value=np.nan, inplace=True)
         self.diaForcedSources.replace(to_replace=[None], value=np.nan,


### PR DESCRIPTION
APDB interface replaced the use of daf_base.DateTime with astropy Time, this patch updates client code to convert DateTtime to astropy Time when passing arguments to Apdb.