### PR TITLE
DM-43590: Add timeout config field

### DIFF
--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -89,6 +89,13 @@ class PackageAlertsConfig(pexConfig.Config):
         default=False,
     )
 
+    maxTimeout = pexConfig.Field(
+        dtype=float,
+        doc="Sets the maximum time in seconds to wait for the alert stream "
+            "broker to respond to a query before timing out.",
+        default=15.0,
+    )
+
 
 class PackageAlertsTask(pipeBase.Task):
     """Tasks for packaging Dia and Pipelines data into Avro alert packages.
@@ -596,7 +603,7 @@ class PackageAlertsTask(pipeBase.Task):
                     present.
                 """
         admin_client = AdminClient(self.kafkaAdminConfig)
-        topics = admin_client.list_topics(timeout=0.5).topics
+        topics = admin_client.list_topics(timeout=self.config.maxTimeout).topics
 
         if not topics:
             raise RuntimeError()


### PR DESCRIPTION
Add timeout config to packageAlerts and set the default to 15 seconds. The current static timeout appears to be too short, causing timeouts when the pipeline initializes and intermittently when alerts are being sent. 