### PR TITLE
DM-43618: ap_association tests leave apdb.sqlite3 files behind

### DIFF
--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -58,6 +58,8 @@ class TestLoadDiaCatalogs(unittest.TestCase):
 
         self.db_file_fd, self.db_file = tempfile.mkstemp(
             dir=os.path.dirname(__file__))
+        self.addCleanup(os.remove, self.db_file)
+        self.addCleanup(os.close, self.db_file_fd)
 
         self.apdbConfig = ApdbSql.init_database(db_url="sqlite:///" + self.db_file)
         self.apdb = Apdb.from_config(self.apdbConfig)
@@ -83,10 +85,6 @@ class TestLoadDiaCatalogs(unittest.TestCase):
         # These columns are not in the DPDD, yet do appear in DiaSource.yaml.
         # We don't need to check them against the default APDB schema.
         self.ignoreColumns = ["band", "bboxSize", "isDipole"]
-
-    def tearDown(self):
-        os.close(self.db_file_fd)
-        os.remove(self.db_file)
 
     def testRun(self):
         """Test the full run method for the loader.


### PR DESCRIPTION
This PR cleans up handling of temporary files and directories in this package's unit tests. There are no references to `tempfile` in the library code itself.