### PR TITLE
DM-43501: Add delivery timeout config

### DIFF
--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -96,6 +96,13 @@ class PackageAlertsConfig(pexConfig.Config):
         default=15.0,
     )
 
+    deliveryTimeout = pexConfig.Field(
+        dtype=float,
+        doc="Sets the time to wait for the producer to wait to deliver an "
+            "alert in milliseconds.",
+        default=1200.0,
+    )
+
 
 class PackageAlertsTask(pipeBase.Task):
     """Tasks for packaging Dia and Pipelines data into Avro alert packages.
@@ -145,6 +152,7 @@ class PackageAlertsTask(pipeBase.Task):
                     # We set the batch size to 2 Mb.
                     "batch.size": 2097152,
                     "linger.ms": 5,
+                    "delivery.timeout.ms": self.config.deliveryTimeout,
                 }
                 self.kafkaAdminConfig = {
                     # This is the URL to use to connect to the Kafka cluster.
@@ -325,7 +333,6 @@ class PackageAlertsTask(pipeBase.Task):
             ccdVisitId of the alerts sent to the alert stream. Used to write
             out alerts which fail to be sent to the alert stream.
         """
-        self._server_check()
         for alert in alerts:
             alertBytes = self._serializeAlert(alert, schema=self.alertSchema.definition, schema_id=1)
             try:

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -412,7 +412,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
         producer_instance.flush = Mock()
         packageAlerts.produceAlerts(alerts, ccdVisitId)
 
-        self.assertEqual(mock_server_check.call_count, 2)
+        self.assertEqual(mock_server_check.call_count, 1)
         self.assertEqual(producer_instance.produce.call_count, len(alerts))
         self.assertEqual(producer_instance.flush.call_count, len(alerts)+1)
 
@@ -447,7 +447,7 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
 
         packageAlerts.produceAlerts(alerts, ccdVisitId)
 
-        self.assertEqual(mock_server_check.call_count, 2)
+        self.assertEqual(mock_server_check.call_count, 1)
         self.assertEqual(producer_instance.produce.call_count, len(alerts))
         self.assertEqual(patch_open.call_count, 1)
         self.assertIn("123_2.avro", patch_open.call_args.args[0])


### PR DESCRIPTION
Add a delivery timeout config to package alerts. Removed check_server from before the alerts are sent as it now timeouts very quickly if there are any sending issues.