### PR TITLE
DM-42744: Fix random seeds for `ap_association` unit tests

### DIFF
--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -68,6 +68,10 @@ class TestDiaPipelineTask(unittest.TestCase):
         return config
 
     def setUp(self):
+        # Create an instance of random generator with fixed seed.
+        rng = np.random.default_rng(1234)
+        self.rng = rng
+
         # schemas are persisted in both Gen 2 and Gen 3 butler as prototypical catalogs
         srcSchema = afwTable.SourceTable.makeMinimalSchema()
         srcSchema.addField("base_PixelFlags_flag", type="Flag")
@@ -248,7 +252,7 @@ class TestDiaPipelineTask(unittest.TestCase):
         nObj0 = 20
 
         # Create diaObjects
-        diaObjects = makeDiaObjects(nObj0, exposure)
+        diaObjects = makeDiaObjects(nObj0, exposure, self.rng)
         # Shrink the bounding box so that some of the diaObjects will be outside
         bbox = exposure.getBBox()
         size = np.minimum(bbox.getHeight(), bbox.getWidth())

--- a/tests/test_loadDiaCatalogs.py
+++ b/tests/test_loadDiaCatalogs.py
@@ -54,7 +54,8 @@ def _data_file_name(basename, module_name):
 class TestLoadDiaCatalogs(unittest.TestCase):
 
     def setUp(self):
-        np.random.seed(1234)
+        # Create an instance of random generator with fixed seed.
+        rng = np.random.default_rng(1234)
 
         self.db_file_fd, self.db_file = tempfile.mkstemp(
             dir=os.path.dirname(__file__))
@@ -66,15 +67,11 @@ class TestLoadDiaCatalogs(unittest.TestCase):
 
         self.exposure = makeExposure(False, False)
 
-        self.diaObjects = makeDiaObjects(20, self.exposure)
+        self.diaObjects = makeDiaObjects(20, self.exposure, rng)
         self.diaSources = makeDiaSources(
-            100,
-            self.diaObjects["diaObjectId"].to_numpy(),
-            self.exposure)
+            100, self.diaObjects["diaObjectId"].to_numpy(), self.exposure, rng)
         self.diaForcedSources = makeDiaForcedSources(
-            200,
-            self.diaObjects["diaObjectId"].to_numpy(),
-            self.exposure)
+            200, self.diaObjects["diaObjectId"].to_numpy(), self.exposure, rng)
 
         self.dateTime = self.exposure.visitInfo.date
         self.apdb.store(self.dateTime.toAstropy(),

--- a/tests/test_trailedSourceFilter.py
+++ b/tests/test_trailedSourceFilter.py
@@ -38,7 +38,9 @@ class TestTrailedSourceFilterTask(unittest.TestCase):
         The trail lengths of the dia sources are 0, 5.5, 11, 16.5, 21.5
         arcseconds.
         """
+        # Create an instance of random generator with fixed seed.
         rng = np.random.default_rng(1234)
+
         scatter = 0.1 / 3600
         self.nSources = 5
         self.diaSources = pd.DataFrame(data=[

--- a/tests/test_transformDiaSourceCatalog.py
+++ b/tests/test_transformDiaSourceCatalog.py
@@ -41,6 +41,9 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 class TestTransformDiaSourceCatalogTask(unittest.TestCase):
     def setUp(self):
+        # Create an instance of random generator with fixed seed.
+        rng = np.random.default_rng(1234)
+
         # The first source will be a sky source.
         self.nSources = 10
         # Default PSF size (psfDim in makeEmptyExposure) in TestDataset results
@@ -72,7 +75,7 @@ class TestTransformDiaSourceCatalogTask(unittest.TestCase):
         self.reliability = lsst.afw.table.BaseCatalog(reliabilitySchema)
         self.reliability.resize(len(self.inputCatalog))
         self.reliability["id"] = self.inputCatalog["id"]
-        self.reliability["score"] = np.random.random(len(self.inputCatalog))
+        self.reliability["score"] = rng.random(len(self.inputCatalog))
 
         self.expId = 4321
         self.date = dafBase.DateTime(nsecs=1400000000 * 10**9)

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -33,7 +33,7 @@ import lsst.daf.base as dafBase
 import lsst.geom
 
 
-def makeDiaObjects(nObjects, exposure):
+def makeDiaObjects(nObjects, exposure, rng):
     """Make a test set of DiaObjects.
 
     Parameters
@@ -49,8 +49,8 @@ def makeDiaObjects(nObjects, exposure):
         DiaObjects generated across the exposure.
     """
     bbox = lsst.geom.Box2D(exposure.getBBox())
-    rand_x = np.random.uniform(bbox.getMinX(), bbox.getMaxX(), size=nObjects)
-    rand_y = np.random.uniform(bbox.getMinY(), bbox.getMaxY(), size=nObjects)
+    rand_x = rng.uniform(bbox.getMinX(), bbox.getMaxX(), size=nObjects)
+    rand_y = rng.uniform(bbox.getMinY(), bbox.getMaxY(), size=nObjects)
 
     midpointMjdTai = exposure.visitInfo.date.get(system=dafBase.DateTime.MJD)
 
@@ -74,7 +74,7 @@ def makeDiaObjects(nObjects, exposure):
     return pd.DataFrame(data=data)
 
 
-def makeDiaSources(nSources, diaObjectIds, exposure, randomizeObjects=False):
+def makeDiaSources(nSources, diaObjectIds, exposure, rng, randomizeObjects=False):
     """Make a test set of DiaSources.
 
     Parameters
@@ -96,10 +96,10 @@ def makeDiaSources(nSources, diaObjectIds, exposure, randomizeObjects=False):
         DiaSources generated across the exposure.
     """
     bbox = lsst.geom.Box2D(exposure.getBBox())
-    rand_x = np.random.uniform(bbox.getMinX(), bbox.getMaxX(), size=nSources)
-    rand_y = np.random.uniform(bbox.getMinY(), bbox.getMaxY(), size=nSources)
+    rand_x = rng.uniform(bbox.getMinX(), bbox.getMaxX(), size=nSources)
+    rand_y = rng.uniform(bbox.getMinY(), bbox.getMaxY(), size=nSources)
     if randomizeObjects:
-        objectIds = diaObjectIds[np.random.randint(len(diaObjectIds), size=nSources)]
+        objectIds = diaObjectIds[rng.randint(len(diaObjectIds), size=nSources)]
     else:
         objectIds = diaObjectIds[[i % len(diaObjectIds) for i in range(nSources)]]
 
@@ -129,7 +129,7 @@ def makeDiaSources(nSources, diaObjectIds, exposure, randomizeObjects=False):
     return pd.DataFrame(data=data)
 
 
-def makeDiaForcedSources(nForcedSources, diaObjectIds, exposure, randomizeObjects=False):
+def makeDiaForcedSources(nForcedSources, diaObjectIds, exposure, rng, randomizeObjects=False):
     """Make a test set of DiaSources.
 
     Parameters
@@ -152,7 +152,7 @@ def makeDiaForcedSources(nForcedSources, diaObjectIds, exposure, randomizeObject
     midpointMjdTai = exposure.visitInfo.date.get(system=dafBase.DateTime.MJD)
     ccdVisitId = exposure.info.id
     if randomizeObjects:
-        objectIds = diaObjectIds[np.random.randint(len(diaObjectIds), size=nForcedSources)]
+        objectIds = diaObjectIds[rng.randint(len(diaObjectIds), size=nForcedSources)]
     else:
         objectIds = diaObjectIds[[i % len(diaObjectIds) for i in range(nForcedSources)]]
 


### PR DESCRIPTION
Set up random generator seed in two places, main location is the `utils_tests.py` that is reused broadly.

## Checklist

- [x] ran Jenkins
- [x] ran local unit tests