### PR TITLE
DM-43416: Migrate AP code to external APDB configs

### DIFF
--- a/doc/lsst.ap.association/index.rst
+++ b/doc/lsst.ap.association/index.rst
@@ -24,7 +24,7 @@ Contributing
 ============
 
 ``lsst.ap.association`` is developed at https://github.com/lsst/ap_association.
-You can find Jira issues for this module under the `ap_association <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_association>`_ component.
+You can find Jira issues for this module under the `ap_association <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_association>`_ component.
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 

--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -214,9 +214,17 @@ class DiaPipelineConfig(pipeBase.PipelineTaskConfig,
         dtype=str,
         default="deep",
     )
-    apdb = daxApdb.ApdbSql.makeField(
+    apdb = daxApdb.ApdbSql.makeField(  # TODO: remove on DM-43419
         doc="Database connection for storing associated DiaSources and "
             "DiaObjects. Must already be initialized.",
+    )
+    apdb_config_url = pexConfig.Field(
+        dtype=str,
+        default=None,
+        optional=False,
+        doc="A config file specifying the APDB and its connection parameters, "
+            "typically written by the apdb-cli command-line utility. "
+            "The database must already be initialized.",
     )
     validBands = pexConfig.ListField(
         dtype=str,
@@ -293,6 +301,14 @@ class DiaPipelineConfig(pipeBase.PipelineTaskConfig,
             "diaObjects for association.",
     )
     idGenerator = DetectorVisitIdGeneratorConfig.make_field()
+    doConfigureApdb = pexConfig.Field(  # TODO: remove on DM-43419
+        dtype=bool,
+        default=True,
+        doc="Use the deprecated ``apdb`` sub-config to set up the APDB, "
+            "instead of the new config (``apdb_config_url``). This field is "
+            "provided for backward-compatibility ONLY and will be removed "
+            "without notice alongside ``apdb``.",
+    )
 
     def setDefaults(self):
         self.apdb.dia_object_index = "baseline"
@@ -314,6 +330,14 @@ class DiaPipelineConfig(pipeBase.PipelineTaskConfig,
                                        "ap_meanTotFlux",
                                        "ap_sigmaTotFlux"]
 
+    # TODO: remove on DM-43419
+    def validate(self):
+        # Sidestep Config.validate to avoid validating uninitialized fields we're not using.
+        skip = {"apdb_config_url"} if self.doConfigureApdb else {"apdb"}
+        for name, field in self._fields.items():
+            if name not in skip:
+                field.validate(self)
+
 
 class DiaPipelineTask(pipeBase.PipelineTask):
     """Task for loading, associating and storing Difference Image Analysis
@@ -324,7 +348,10 @@ class DiaPipelineTask(pipeBase.PipelineTask):
 
     def __init__(self, initInputs=None, **kwargs):
         super().__init__(**kwargs)
-        self.apdb = self.config.apdb.apply()
+        if self.config.doConfigureApdb:
+            self.apdb = self.config.apdb.apply()
+        else:
+            self.apdb = daxApdb.Apdb.from_uri(self.config.apdb_config_url)
         self.makeSubtask("diaCatalogLoader")
         self.makeSubtask("associator")
         self.makeSubtask("diaCalculation")
@@ -580,7 +607,10 @@ class DiaPipelineTask(pipeBase.PipelineTask):
                                    doRunForcedMeasurement=self.config.doRunForcedMeasurement,
                                    )
 
-        return pipeBase.Struct(apdbMarker=self.config.apdb.value,
+        # For historical reasons, apdbMarker is a Config even if it's not meant to be read.
+        # A default Config is the cheapest way to satisfy the storage class.
+        marker = self.config.apdb.value if self.config.doConfigureApdb else pexConfig.Config()
+        return pipeBase.Struct(apdbMarker=marker,
                                associatedDiaSources=associatedDiaSources,
                                diaForcedSources=diaForcedSources,
                                diaObjects=diaObjects,

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -147,36 +147,34 @@ class TestDiaPipelineTask(unittest.TestCase):
 
         # apdb isn't a subtask, but still needs to be mocked out for correct
         # execution in the test environment.
-        with patch.multiple(
-            task, **{task: DEFAULT for task in subtasksToMock + ["apdb"]}
-        ):
-            with patch('lsst.ap.association.diaPipe.pd.concat', new=concatMock), \
-                patch('lsst.ap.association.association.AssociationTask.run', new=associator_run), \
-                patch('lsst.ap.association.ssoAssociation.SolarSystemAssociationTask.run',
-                      new=solarSystemAssociator_run):
+        with patch.multiple(task, **{task: DEFAULT for task in subtasksToMock + ["apdb"]}), \
+            patch('lsst.ap.association.diaPipe.pd.concat', new=concatMock), \
+            patch('lsst.ap.association.association.AssociationTask.run', new=associator_run), \
+            patch('lsst.ap.association.ssoAssociation.SolarSystemAssociationTask.run',
+                  new=solarSystemAssociator_run):
 
-                result = task.run(diaSrc,
-                                  ssObjects,
-                                  diffIm,
-                                  exposure,
-                                  template,
-                                  ccdExposureIdBits,
-                                  "g")
-                for subtaskName in subtasksToMock:
-                    getattr(task, subtaskName).run.assert_called_once()
-                assertValidOutput(task, result)
-                self.assertEqual(result.apdbMarker.db_url, "sqlite://")
-                meta = task.getFullMetadata()
-                # Check that the expected metadata has been set.
-                self.assertEqual(meta["diaPipe.numUpdatedDiaObjects"], 2)
-                self.assertEqual(meta["diaPipe.numUnassociatedDiaObjects"], 3)
-                # and that associators ran once or not at all.
-                self.assertEqual(len(meta.getArray("diaPipe:associator.associator_runEndUtc")), 1)
-                if doSolarSystemAssociation:
-                    self.assertEqual(len(meta.getArray("diaPipe:solarSystemAssociator."
-                                                       "solarSystemAssociator_runEndUtc")), 1)
-                else:
-                    self.assertNotIn("diaPipe:solarSystemAssociator", meta)
+            result = task.run(diaSrc,
+                              ssObjects,
+                              diffIm,
+                              exposure,
+                              template,
+                              ccdExposureIdBits,
+                              "g")
+            for subtaskName in subtasksToMock:
+                getattr(task, subtaskName).run.assert_called_once()
+            assertValidOutput(task, result)
+            self.assertEqual(result.apdbMarker.db_url, "sqlite://")
+            meta = task.getFullMetadata()
+            # Check that the expected metadata has been set.
+            self.assertEqual(meta["diaPipe.numUpdatedDiaObjects"], 2)
+            self.assertEqual(meta["diaPipe.numUnassociatedDiaObjects"], 3)
+            # and that associators ran once or not at all.
+            self.assertEqual(len(meta.getArray("diaPipe:associator.associator_runEndUtc")), 1)
+            if doSolarSystemAssociation:
+                self.assertEqual(len(meta.getArray("diaPipe:solarSystemAssociator."
+                                                   "solarSystemAssociator_runEndUtc")), 1)
+            else:
+                self.assertNotIn("diaPipe:solarSystemAssociator", meta)
 
     def test_createDiaObjects(self):
         """Test that creating new DiaObjects works as expected.

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import unittest
+from unittest.mock import patch, Mock, MagicMock, DEFAULT
 import warnings
 
 import numpy as np
@@ -27,13 +28,12 @@ import pandas as pd
 
 import lsst.afw.image as afwImage
 import lsst.afw.table as afwTable
-from lsst.pipe.base.testUtils import assertValidOutput
-from utils_tests import makeExposure, makeDiaObjects
 import lsst.utils.tests
 import lsst.utils.timer
-from unittest.mock import patch, Mock, MagicMock, DEFAULT
+from lsst.pipe.base.testUtils import assertValidOutput
 
 from lsst.ap.association import DiaPipelineTask
+from utils_tests import makeExposure, makeDiaObjects
 
 
 def _makeMockDataFrame():

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -29,7 +29,6 @@ import pandas as pd
 import lsst.afw.image as afwImage
 import lsst.afw.table as afwTable
 import lsst.utils.tests
-import lsst.utils.timer
 from lsst.pipe.base.testUtils import assertValidOutput
 
 from lsst.ap.association import DiaPipelineTask
@@ -131,15 +130,13 @@ class TestDiaPipelineTask(unittest.TestCase):
 
         # Mock out the run() methods of these two Tasks to ensure they
         # return data in the correct form.
-        @lsst.utils.timer.timeMethod
-        def solarSystemAssociator_run(self, unAssocDiaSources, solarSystemObjectTable, diffIm):
+        def solarSystemAssociator_run(unAssocDiaSources, solarSystemObjectTable, diffIm):
             return lsst.pipe.base.Struct(nTotalSsObjects=42,
                                          nAssociatedSsObjects=30,
                                          ssoAssocDiaSources=_makeMockDataFrame(),
                                          unAssocDiaSources=_makeMockDataFrame())
 
-        @lsst.utils.timer.timeMethod
-        def associator_run(self, table, diaObjects, exposure_time=None):
+        def associator_run(table, diaObjects, exposure_time=None):
             return lsst.pipe.base.Struct(nUpdatedDiaObjects=2, nUnassociatedDiaObjects=3,
                                          matchedDiaSources=_makeMockDataFrame(),
                                          unAssocDiaSources=_makeMockDataFrame(),
@@ -148,10 +145,11 @@ class TestDiaPipelineTask(unittest.TestCase):
         # apdb isn't a subtask, but still needs to be mocked out for correct
         # execution in the test environment.
         with patch.multiple(task, **{task: DEFAULT for task in subtasksToMock + ["apdb"]}), \
-            patch('lsst.ap.association.diaPipe.pd.concat', new=concatMock), \
-            patch('lsst.ap.association.association.AssociationTask.run', new=associator_run), \
+            patch('lsst.ap.association.diaPipe.pd.concat', side_effect=concatMock), \
+            patch('lsst.ap.association.association.AssociationTask.run',
+                  side_effect=associator_run) as mainRun, \
             patch('lsst.ap.association.ssoAssociation.SolarSystemAssociationTask.run',
-                  new=solarSystemAssociator_run):
+                  side_effect=solarSystemAssociator_run) as ssRun:
 
             result = task.run(diaSrc,
                               ssObjects,
@@ -169,12 +167,11 @@ class TestDiaPipelineTask(unittest.TestCase):
             self.assertEqual(meta["diaPipe.numUpdatedDiaObjects"], 2)
             self.assertEqual(meta["diaPipe.numUnassociatedDiaObjects"], 3)
             # and that associators ran once or not at all.
-            self.assertEqual(len(meta.getArray("diaPipe:associator.associator_runEndUtc")), 1)
+            mainRun.assert_called_once()
             if doSolarSystemAssociation:
-                self.assertEqual(len(meta.getArray("diaPipe:solarSystemAssociator."
-                                                   "solarSystemAssociator_runEndUtc")), 1)
+                ssRun.assert_called_once()
             else:
-                self.assertNotIn("diaPipe:solarSystemAssociator", meta)
+                ssRun.assert_not_called()
 
     def test_createDiaObjects(self):
         """Test that creating new DiaObjects works as expected.

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -28,6 +28,7 @@ import pandas as pd
 
 import lsst.afw.image as afwImage
 import lsst.afw.table as afwTable
+import lsst.pex.config as pexConfig
 import lsst.utils.tests
 from lsst.pipe.base.testUtils import assertValidOutput
 
@@ -69,8 +70,39 @@ class TestDiaPipelineTask(unittest.TestCase):
         srcSchema.addField("base_PixelFlags_flag_offimage", type="Flag")
         self.srcSchema = afwTable.SourceCatalog(srcSchema)
 
-    def tearDown(self):
-        pass
+    # TODO: remove on DM-43419
+    def testConfigApdbNestedOk(self):
+        config = DiaPipelineTask.ConfigClass()
+        config.doConfigureApdb = True
+        config.apdb.db_url = "sqlite://"
+        config.freeze()
+        config.validate()
+
+    # TODO: remove on DM-43419
+    def testConfigApdbNestedInvalid(self):
+        config = DiaPipelineTask.ConfigClass()
+        config.doConfigureApdb = True
+        # Don't set db_url
+        config.freeze()
+        with self.assertRaises(pexConfig.FieldValidationError):
+            config.validate()
+
+    # TODO: remove on DM-43419
+    def testConfigApdbFileOk(self):
+        config = DiaPipelineTask.ConfigClass()
+        config.doConfigureApdb = False
+        config.apdb_config_url = "some/file/path.yaml"
+        config.freeze()
+        config.validate()
+
+    # TODO: remove on DM-43419
+    def testConfigApdbFileInvalid(self):
+        config = DiaPipelineTask.ConfigClass()
+        config.doConfigureApdb = False
+        # Don't set apdb_config_url
+        config.freeze()
+        with self.assertRaises(pexConfig.FieldValidationError):
+            config.validate()
 
     def testRun(self):
         """Test running while creating and packaging alerts.


### PR DESCRIPTION
This PR modifies `DiaPipelineTask` to use new-style configs instead of a nested `ApdbConfig` field, and updates the unit tests for `TestTotalUnassociatedObjects` to reflect lsst/verify#124. It also does some simplification of the task's unit tests.