### PR TITLE
DM-44279: Remove extra print statement from FilterDiaSourceCatalogTask

### DIFF
--- a/python/lsst/ap/association/filterDiaSourceCatalog.py
+++ b/python/lsst/ap/association/filterDiaSourceCatalog.py
@@ -221,7 +221,6 @@ class FilterDiaSourceCatalogTask(pipeBase.PipelineTask):
             detector (off_image set). Also checks if both
             suspect_long_trail and edge are set and masks those sources out.
         """
-        print(dia_sources.getSchema())
         trail_mask = (dia_sources["ext_trailedSources_Naive_length"]
                       >= (self.config.max_trail_length*exposure_time))
         trail_mask |= dia_sources['ext_trailedSources_Naive_flag_off_image']


### PR DESCRIPTION
This PR removes a temporary `print` statement that was bypassing the logger.