### PR TITLE
DM-41873: Add max cutout size to packageAlerts

### DIFF
--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -64,6 +64,17 @@ class PackageAlertsConfig(pexConfig.Config):
         default=30,
         doc="Dimension of the square image cutouts to package in the alert."
     )
+    maxCutoutSize = pexConfig.RangeField(
+        dtype=int,
+        min=0,
+        max=1000,
+        default=102,
+        doc="Dimension of the square image cutouts to package in the alert. The"
+            "default size comes from the max trail length in arcseconds "
+            "(10 deg/day) for a 30 second observation divided by the"
+            "arcseconds per pixel (0.2), which is 62.5 pixels. The effective"
+            "size of the psf (40 pixels) is then added for a total of 102 pixels. "
+    )
     alertWriteLocation = pexConfig.Field(
         dtype=str,
         doc="Location to write alerts to.",
@@ -318,6 +329,9 @@ class PackageAlertsTask(pipeBase.Task):
         if bboxSize < self.config.minCutoutSize:
             extent = geom.Extent2I(self.config.minCutoutSize,
                                    self.config.minCutoutSize)
+        elif bboxSize > self.config.maxCutoutSize:
+            extent = geom.Extent2I(self.config.maxCutoutSize,
+                                   self.config.maxCutoutSize)
         else:
             extent = geom.Extent2I(bboxSize, bboxSize)
         return extent

--- a/tests/test_packageAlerts.py
+++ b/tests/test_packageAlerts.py
@@ -211,18 +211,36 @@ class TestPackageAlerts(lsst.utils.tests.TestCase):
         self.cutoutWcs.wcs.cd = self.exposure.getWcs().getCdMatrix()
         self.cutoutWcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
 
-    def testCreateExtent(self):
-        """Test the extent creation for the cutout bbox.
+    def testCreateExtentMinimum(self):
+        """Test the extent creation for the cutout bbox returns a cutout with
+        the minimum cutouut size.
         """
         packConfig = PackageAlertsConfig()
-        # Just create a minimum less than the default cutout.
+        # Just create a minimum less than the default cutout size.
         packConfig.minCutoutSize = self.cutoutSize - 5
         packageAlerts = PackageAlertsTask(config=packConfig)
         extent = packageAlerts.createDiaSourceExtent(
             packConfig.minCutoutSize - 5)
         self.assertTrue(extent == geom.Extent2I(packConfig.minCutoutSize,
                                                 packConfig.minCutoutSize))
-        # Test that the cutout size is correct.
+        # Test that the cutout size is correctly increased.
+        extent = packageAlerts.createDiaSourceExtent(self.cutoutSize)
+        self.assertTrue(extent == geom.Extent2I(self.cutoutSize,
+                                                self.cutoutSize))
+
+    def testCreateExtentMaximum(self):
+        """Test the extent creation for the cutout bbox returns a cutout with
+        the maximum cutout size.
+        """
+        packConfig = PackageAlertsConfig()
+        # Just create a maximum more than the default cutout size.
+        packConfig.maxCutoutSize = self.cutoutSize + 5
+        packageAlerts = PackageAlertsTask(config=packConfig)
+        extent = packageAlerts.createDiaSourceExtent(
+            packConfig.maxCutoutSize + 5)
+        self.assertTrue(extent == geom.Extent2I(packConfig.maxCutoutSize,
+                                                packConfig.maxCutoutSize))
+        # Test that the cutout size is correctly reduced.
         extent = packageAlerts.createDiaSourceExtent(self.cutoutSize)
         self.assertTrue(extent == geom.Extent2I(self.cutoutSize,
                                                 self.cutoutSize))


### PR DESCRIPTION
For some alerts, the footprint size allows the creation of cutouts which are far too large. This ticket adds a maxCutoutSize config to limit the maximum size. The maximum size will be the maximum trail length allowed for a 30 second exposure in pixels (62.5) plus the expected psf size (40 pixels). This comes to 102 pixels. 