### PR TITLE
DM-44937: DiaForcedSource tables indexed by class, not integer

### DIFF
--- a/python/lsst/ap/association/utils.py
+++ b/python/lsst/ap/association/utils.py
@@ -215,7 +215,7 @@ def make_empty_catalog(apdbSchema, tableName):
     table = apdbSchema[tableName]
 
     data = {
-        columnDef.name: pd.Series(column_dtype(columnDef.datatype))
+        columnDef.name: pd.Series(dtype=column_dtype(columnDef.datatype))
         for columnDef in table.columns
     }
     return pd.DataFrame(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,8 @@ class TestUtils(unittest.TestCase):
         tableNames = ["DiaObject", "DiaSource", "DiaForcedSource"]
         for tableName in tableNames:
             emptyDiaObjects = make_empty_catalog(schema, tableName=tableName)
+            self.assertTrue(emptyDiaObjects.empty)
+
             emptyColumns = set(emptyDiaObjects.columns)
             self.assertIn("ra", emptyColumns)
             self.assertIn("dec", emptyColumns)
@@ -47,4 +49,7 @@ class TestUtils(unittest.TestCase):
             emptyDf = pd.DataFrame(columns=["diaObjectId",])
             emptyDf.set_index("diaObjectId")
             convertedEmptyDiaObjects = convertTableToSdmSchema(schema, emptyDf, tableName=tableName)
-            self.assertEqual(set(convertedEmptyDiaObjects.columns), emptyColumns)
+            # TODO: we have no tests of convertTableToSdmSchema, so it's dangerous to use it as an oracle.
+            emptyTypes = dict(zip(emptyDiaObjects.columns, emptyDiaObjects.dtypes))
+            convertedEmptyTypes = dict(zip(convertedEmptyDiaObjects.columns, convertedEmptyDiaObjects.dtypes))
+            self.assertEqual(emptyTypes, convertedEmptyTypes)


### PR DESCRIPTION
This PR fixes a bug in which `make_empty_catalog` did not create an empty catalog and did not convert the input schema to Pandas datatypes.