### PR TITLE
DM-45023: Add close to producer

### DIFF
--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -306,6 +306,7 @@ class PackageAlertsTask(pipeBase.Task):
 
         if self.config.doProduceAlerts:
             self.produceAlerts(alerts, visit, detector)
+            self.producer.close()
 
         if self.config.doWriteAlerts:
             with open(os.path.join(self.config.alertWriteLocation, f"{visit}_{detector}.avro"), "wb") as f:


### PR DESCRIPTION
Add producer.close() to the alert producer to ensure that the producer closes safely.