### PR TITLE
DM-43599: Add progress logs to DiaPipelineTask

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -569,7 +569,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
 
         # Store DiaSources, updated DiaObjects, and DiaForcedSources in the
         # Apdb.
-        self.log.info(f"Updating {len(diaForcedSources)} diaForcedSources from the APDB")
+        self.log.info(f"Updating {len(diaForcedSources)} diaForcedSources in the APDB")
         diaForcedSources = convertTableToSdmSchema(self.schema, diaForcedSources,
                                                    tableName="DiaForcedSource",
                                                    )
@@ -582,6 +582,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
             diaObjectStore,
             diaSourceStore,
             diaForcedSourceStore)
+        self.log.info("APDB updated.")
 
         if self.config.doPackageAlerts:
             if len(loaderResult.diaForcedSources) > 1:

--- a/python/lsst/ap/association/loadDiaCatalogs.py
+++ b/python/lsst/ap/association/loadDiaCatalogs.py
@@ -138,6 +138,8 @@ class LoadDiaCatalogsTask(pipeBase.Task):
             DiaObjects loaded from the Apdb that are within the area defined
             by ``pixelRanges``.
         """
+        self.log.info("Loading DiaObjects")
+
         if region is None:
             # If no area is specified return an empty DataFrame with the
             # the column used for indexing later in AssociationTask.
@@ -182,6 +184,8 @@ class LoadDiaCatalogsTask(pipeBase.Task):
             DiaSources loaded from the Apdb that are within the area defined
             by ``pixelRange`` and associated with ``diaObjects``.
         """
+        self.log.info("Loading DiaSources")
+
         if region is None:
             # If no area is specified return an empty DataFrame with the
             # the column used for indexing later in AssociationTask.
@@ -230,6 +234,8 @@ class LoadDiaCatalogsTask(pipeBase.Task):
             DiaObjects loaded from the Apdb that are within the area defined
             by ``pixelRanges``.
         """
+        self.log.info("Loading DiaForcedSources")
+
         if len(diaObjects) == 0:
             # If no diaObjects are available return an empty DataFrame with
             # the the column used for indexing later in AssociationTask.


### PR DESCRIPTION
This PR adds standard status logs to APDB loading, APDB storage, and alert packaging, all steps of `DiaPipelineTask` in which the code may fail to log for a minute or more. The lack of prior logging in PackageAlertsTask means it's hard to tell how much of the silence is from `apdb.store` and how much from packaging.

This PR also adds a loop logger (`utils.logging.PeriodicLogger`) to `PackageAlertsTask`. No such logging is practical for `Apdb` implementations, which treats the DB operations as bulk reads or writes rather than an explicit loop.