### PR TITLE
DM-45789: Optimize region for LoadDiaCatalogs

### DIFF
--- a/python/lsst/ap/association/loadDiaCatalogs.py
+++ b/python/lsst/ap/association/loadDiaCatalogs.py
@@ -143,10 +143,8 @@ class LoadDiaCatalogsTask(pipeBase.PipelineTask):
         RuntimeError
             Raised if the Database query failed to load DiaObjects.
         """
-        baseRegion = regionTime.region
-        region = baseRegion.getBoundingCircle()
-        region.dilateBy(lsst.sphgeom.Angle.fromDegrees(self.config.angleMargin/3600.))
-
+        region = self._paddedRegion(regionTime.region,
+                                    lsst.sphgeom.Angle.fromDegrees(self.config.angleMargin/3600.))
         schema = readSchemaFromApdb(self.apdb)
 
         # This is the first database query.
@@ -168,6 +166,26 @@ class LoadDiaCatalogsTask(pipeBase.PipelineTask):
             diaObjects=diaObjects,
             diaSources=diaSources,
             diaForcedSources=diaForcedSources)
+
+    @staticmethod
+    def _paddedRegion(region, margin):
+        """Return a region that has been expanded by a buffer.
+
+        Parameters
+        ----------
+        region : `lsst.sphgeom.Region`
+            The region to pad.
+        margin : `lsst.sphgeom.Angle`
+            The amount by which to increase the region.
+
+        Returns
+        -------
+        padded : `lsst.sphgeom.Region`
+            An enlarged copy of ``region``.
+        """
+        circle = region.getBoundingCircle()
+        circle.dilateBy(margin)
+        return circle
 
     @timeMethod
     def loadDiaObjects(self, region, schema):


### PR DESCRIPTION
This PR provides a more precise implementation of `LoadDiaCatalogsConfig.angleMargin` that fits more closely to the detector footprint. The implementation is *not* guaranteed to move all sides of the footprint outward by exactly `angleMargin`, but I assume such precision is not needed in a buffer.