### PR TITLE
DM-47081: Skip packaging missing forced sources

### DIFF
--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -53,8 +53,8 @@ class DiaForcedSourcedConfig(pexConfig.Config):
     historyThreshold = pexConfig.Field(
         dtype=int,
         doc="Minimum number of detections of a diaObject required "
-            "to run forced photometry. Set to 0 to include all diaObjects.",
-        default=1,
+            "to run forced photometry. Set to 1 to include all diaObjects.",
+        default=2,
     )
 
     def setDefaults(self):
@@ -128,7 +128,7 @@ class DiaForcedSourceTask(pipeBase.Task):
             difference and direct images at DiaObject locations.
         """
         # Restrict forced source measurement to objects with sufficient history to be reliable.
-        objectTable = dia_objects.query(f'nDiaSources > {self.config.historyThreshold}')
+        objectTable = dia_objects.query(f'nDiaSources >= {self.config.historyThreshold}')
         if objectTable.empty:
             # The dataframe will be coerced to the correct (empty) format in diaPipe.
             return pd.DataFrame()

--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -497,10 +497,11 @@ class DiaPipelineTask(pipeBase.PipelineTask):
             diaForcedSources = self.runForcedMeasurement(
                 diaCalResult.diaObjectCat, diaCalResult.updatedDiaObjects, exposure, diffIm, idGenerator
             )
-
+            forcedSourceHistoryThreshold = self.diaForcedSource.config.historyThreshold
         else:
             # alertPackager needs correct columns
             diaForcedSources = makeEmptyForcedSourceTable(self.schema)
+            forcedSourceHistoryThreshold = 0
 
         # Write results to Alert Production Database (APDB)
         self.writeToApdb(diaCalResult.updatedDiaObjects, associatedDiaSources, diaForcedSources)
@@ -533,6 +534,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
                                    exposure,
                                    template,
                                    doRunForcedMeasurement=self.config.doRunForcedMeasurement,
+                                   forcedSourceHistoryThreshold=forcedSourceHistoryThreshold,
                                    )
 
         # For historical reasons, apdbMarker is a Config even if it's not meant to be read.

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -210,6 +210,7 @@ class PackageAlertsTask(pipeBase.Task):
             calexp,
             template,
             doRunForcedMeasurement=True,
+            forcedSourceHistoryThreshold=0,
             ):
         """Package DiaSources/Object and exposure data into Avro alerts.
 
@@ -246,6 +247,9 @@ class PackageAlertsTask(pipeBase.Task):
             This should only be turned off for debugging purposes.
             Added to allow disabling forced sources for performance
             reasons during the ops rehearsal.
+        forcedSourceHistoryThreshold : `int`, optional
+            Minimum number of detections of a diaObject required
+            to run forced photometry. Set to 1 to include all diaObjects.
         """
         alerts = []
         self._patchDiaSources(diaSourceCat)
@@ -276,7 +280,7 @@ class PackageAlertsTask(pipeBase.Task):
                 objSourceHistory = diaSrcHistory.loc[srcIndex[0]]
             else:
                 objSourceHistory = None
-            if doRunForcedMeasurement and not diaForcedSources.empty:
+            if doRunForcedMeasurement and diaObject["nDiaSources"] >= forcedSourceHistoryThreshold:
                 objDiaForcedSources = diaForcedSources.loc[srcIndex[0]]
             else:
                 # Send empty table with correct columns


### PR DESCRIPTION
DiaObjects with too few detections are now skipped for running forced photometry. When packaging alerts, we must also skip packaging those forced sources.