### PR TITLE
DM-47274: Ensure that the DiaObject table has correct format after update

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -931,8 +931,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
             mergedCatalog = pd.concat([originalCatalog], sort=True)
         return mergedCatalog.loc[:, originalCatalog.columns]
 
-    @staticmethod
-    def updateObjectTable(diaObjects, diaSources):
+    def updateObjectTable(self, diaObjects, diaSources):
         """Update the diaObject table with the new diaSource records.
 
         Parameters
@@ -951,4 +950,4 @@ class DiaPipelineTask(pipeBase.PipelineTask):
         nDiaSources.rename({"diaSourceId": "nDiaSources"}, errors="raise", axis="columns", inplace=True)
         del diaObjects["nDiaSources"]
         updatedDiaObjects = diaObjects.join(nDiaSources, how="left")
-        return updatedDiaObjects
+        return convertTableToSdmSchema(self.schema, updatedDiaObjects, tableName="DiaObject")

--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -355,6 +355,8 @@ class TestDiaPipelineTask(unittest.TestCase):
         """Test that the diaObject record is updated with the number of
         diaSources.
         """
+        config = self._makeDefaultConfig(config_file=self.config_file.name, doPackageAlerts=False)
+        task = DiaPipelineTask(config=config)
         nObjects = 20
         nSrcPerObject = 10
         nExtraSources = 5
@@ -363,7 +365,7 @@ class TestDiaPipelineTask(unittest.TestCase):
         expectedSourcesPerObject[:nExtraSources] += 1
         diaObjects = makeDiaObjects(nObjects, self.exposure, self.rng)
         diaSources = makeDiaSources(nSources, diaObjects["diaObjectId"].to_numpy(), self.exposure, self.rng)
-        updatedDiaObjects = DiaPipelineTask.updateObjectTable(diaObjects, diaSources)
+        updatedDiaObjects = task.updateObjectTable(diaObjects, diaSources)
         self.assertTrue(np.all(updatedDiaObjects.nDiaSources.values == expectedSourcesPerObject))
 
 


### PR DESCRIPTION
The DiaObject table is relatively small, so an additional check on the format is not too expensive.