### PR TITLE
DM-47620 Match single frame association connections to prompt processing

### DIFF
--- a/python/lsst/ap/association/ssSingleFrameAssociation.py
+++ b/python/lsst/ap/association/ssSingleFrameAssociation.py
@@ -44,13 +44,13 @@ class SsSingleFrameAssociationConnections(
     """
     exposure = connTypes.Input(
         doc="Exposure from which source table was generated",
-        name="calexp",
+        name="initial_pvi",
         storageClass="ExposureF",
         dimensions=("instrument", "visit", "detector"),
     )
     sourceTable = connTypes.Input(
         doc="Catalog of calibrated Sources.",
-        name="src",
+        name="initial_stars_footprints_detector",
         storageClass="SourceCatalog",
         dimensions=("instrument", "visit", "detector"),
     )


### PR DESCRIPTION
As we move single-frame association into prompt processing, we should match its connections to prompt processing rather than DRP, which it currently matches. calexp -> initial_pvi, src -> initial_stars_footprints_detector. 