### PR TITLE
DM-47648 : Return table of unassociated objects

### DIFF
--- a/tests/test_diaPipe.py
+++ b/tests/test_diaPipe.py
@@ -151,7 +151,8 @@ class TestDiaPipelineTask(unittest.TestCase):
                                          nAssociatedSsObjects=30,
                                          ssoAssocDiaSources=_makeMockDataFrame(),
                                          unAssocDiaSources=_makeMockDataFrame(),
-                                         ssSourceData=_makeMockDataFrame())
+                                         associatedSsSources=_makeMockDataFrame(),
+                                         unassociatedSsObjects=_makeMockDataFrame())
 
         def associator_run(table, diaObjects):
             return lsst.pipe.base.Struct(nUpdatedDiaObjects=2, nUnassociatedDiaObjects=3,


### PR DESCRIPTION
Adds a new dataset, unAssocSsObjects, to the struct returned by ssoAssociation and sends it to the Butler as `ssSingleFrameUnassociatedObjects` through ssSingleFrameAssociation. Doesn't do anything to diaPipe, so this only affects SingleFrame. 