### PR TITLE
DM-48009: Revert #248 "Rename dipole classification "flags” 

### DIFF
--- a/data/DiaSource.yaml
+++ b/data/DiaSource.yaml
@@ -197,10 +197,7 @@ funcs:
         args: ip_diffim_DipoleFit_chi2dof
     isDipole:
         functor: Column
-        args: ip_diffim_DipoleFit_classification
-    dipoleFitAttempted:
-        functor: Column
-        args: ip_diffim_DipoleFit_classificationAttempted
+        args: ip_diffim_DipoleFit_flag_classification
     dipoleNdata:
         functor: Column
         args: ip_diffim_DipoleFit_nData


### PR DESCRIPTION
...and add attempted dipole classification to APDB"

This reverts commit ecbbdbf337399f44f21a0f76abab90345d9bb79b.