### PR TITLE
DM-48095: AP pipeline does not do solar system association

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -262,7 +262,7 @@ class DiaPipelineConfig(pipeBase.PipelineTaskConfig,
     )
     doSolarSystemAssociation = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc="Process SolarSystem objects through the pipeline.",
     )
     solarSystemAssociator = pexConfig.ConfigurableField(

--- a/python/lsst/ap/association/ssoAssociation.py
+++ b/python/lsst/ap/association/ssoAssociation.py
@@ -243,7 +243,6 @@ class SolarSystemAssociationTask(pipeBase.Task):
         return vectors
 
     def _return_empty(self, diaSourceCatalog):
-        self.log.info(str(type(diaSourceCatalog)))
         self.log.info("No SolarSystemObjects found in detector bounding box.")
         return pipeBase.Struct(
             ssoAssocDiaSources=Table(names=diaSourceCatalog.columns),


### PR DESCRIPTION
This PR turns on solar system processing by default, as this behavior is useful (or, at worst, does no harm) for AP pipelines in any environment.