### PR TITLE
DM-49555: Expand diagnostic logs for Prompt Processing

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -491,6 +491,8 @@ class DiaPipelineTask(pipeBase.PipelineTask):
         # Write results to Alert Production Database (APDB)
         self.writeToApdb(updatedDiaObjects, associatedDiaSources, diaForcedSources)
         self.metadata["writeToApdbDuration"] = duration_from_timeMethod(self.metadata, "writeToApdb")
+        # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
+        self.log.debug("writeToApdb: Took %.4f seconds", self.metadata["writeToApdbDuration"])
 
         # Package alerts
         if self.config.doPackageAlerts:

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -382,6 +382,7 @@ class PackageAlertsTask(pipeBase.Task):
             extent = geom.Extent2I(bboxSize, bboxSize)
         return extent
 
+    @timeMethod
     def produceAlerts(self, alerts, visit, detector, midpoint_unix, exposure_time):
         """Serialize alerts and send them to the alert stream using
         confluent_kafka's producer.

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -425,6 +425,9 @@ class PackageAlertsTask(pipeBase.Task):
         self.metadata['produce_start_timestamp'] = produce_start_timestamp
         self.metadata['alert_timing_since_shutter_close'] = total_time
         self.metadata['total_alerts'] = total_alerts
+        # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
+        self.log.debug("Producing alerts: Took %.4f seconds",
+                       produce_end_timestamp - produce_start_timestamp)
 
         self.log.info(f"Total time since shutter close to produce alerts for"
                       f" visit {visit} detector {detector}: {total_time} seconds")


### PR DESCRIPTION
This PR adds an extra `timeMethod` decorator (not useful for PP, but useful in general) and adds explicit, Loki-friendly logs for the things PP cares about.

I'm not sure why both methods use bespoke metadata formats instead of just using `timeMethod` or `time_this`, but I'm not going to try to clean that up here (it would probably break `analysis_tools`).