### PR TITLE
DM-49701: Make ap_association timing logs more visible to Prompt Processing

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -492,7 +492,7 @@ class DiaPipelineTask(pipeBase.PipelineTask):
         self.writeToApdb(updatedDiaObjects, associatedDiaSources, diaForcedSources)
         self.metadata["writeToApdbDuration"] = duration_from_timeMethod(self.metadata, "writeToApdb")
         # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
-        self.log.debug("writeToApdb: Took %.4f seconds", self.metadata["writeToApdbDuration"])
+        self.log.verbose("writeToApdb: Took %.4f seconds", self.metadata["writeToApdbDuration"])
 
         # Package alerts
         if self.config.doPackageAlerts:

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -426,8 +426,8 @@ class PackageAlertsTask(pipeBase.Task):
         self.metadata['alert_timing_since_shutter_close'] = total_time
         self.metadata['total_alerts'] = total_alerts
         # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
-        self.log.debug("Producing alerts: Took %.4f seconds",
-                       produce_end_timestamp - produce_start_timestamp)
+        self.log.verbose("Producing alerts: Took %.4f seconds",
+                         produce_end_timestamp - produce_start_timestamp)
 
         self.log.info(f"Total time since shutter close to produce alerts for"
                       f" visit {visit} detector {detector}: {total_time} seconds")


### PR DESCRIPTION
This PR changes the timing logs added in #272 from debug-level to verbose-level. That makes them easier to read in Prompt Processing without getting overwhelmed (in fact, we already log `lsst.diaPipe` at verbose level).