### PR TITLE
DM-49554: Do not attempt forced photometry in NO_DATA regions

### DIFF
--- a/python/lsst/ap/association/diaForcedSource.py
+++ b/python/lsst/ap/association/diaForcedSource.py
@@ -59,7 +59,8 @@ class DiaForcedSourcedConfig(pexConfig.Config):
 
     def setDefaults(self):
         self.forcedMeasurement.plugins = ["base_TransformedCentroidFromCoord",
-                                          "base_PsfFlux"]
+                                          "base_PsfFlux",
+                                          "base_PixelFlags"]
         self.forcedMeasurement.doReplaceWithNoise = False
         self.forcedMeasurement.copyColumns = {
             "id": "diaObjectId",

--- a/tests/test_diaForcedSource.py
+++ b/tests/test_diaForcedSource.py
@@ -177,7 +177,7 @@ class TestDiaForcedSource(unittest.TestCase):
         # above list of ids.
         self.expectedDiaForcedSources = 6
 
-        self.expected_n_columns = 14
+        self.expected_n_columns = 37
 
     def testRun(self):
         """Test that forced source catalogs are successfully created and have


### PR DESCRIPTION
Add base_PixelFlags plugin to DiaForcedSource.
Forced Photometry now explicitly requires the base_PixelFlags plugin.