### PR TITLE
DM-50462: Add MPSky to Prompt Processing configs

### DIFF
--- a/python/lsst/ap/association/mpSkyEphemerisQuery.py
+++ b/python/lsst/ap/association/mpSkyEphemerisQuery.py
@@ -138,7 +138,11 @@ class MPSkyEphemerisQueryTask(PipelineTask):
         expMidPointEPOCH = getMidpointFromTimespan(timespan, allowUnbounded=False).mjd
 
         # MPSky service query
-        mpSkyURL = os.environ.get('MP_SKY_URL', self.config.mpSkyFallbackURL)
+        try:
+            mpSkyURL = os.environ['MP_SKY_URL']
+        except KeyError:
+            self.log.warning("MP_SKY_URL is not defined. Falling back to %s.", self.config.mpSkyFallbackURL)
+            mpSkyURL = self.config.mpSkyFallbackURL
         mpSkySsObjects = self._mpSkyConeSearch(expCenter, expMidPointEPOCH,
                                                expRadius + self.config.queryBufferRadiusDegrees, mpSkyURL)
         return Struct(


### PR DESCRIPTION
This PR adds a warning if the `MP_SKY_URL` is not defined and `mpSkyEphemerisQuery` needs to fall back to its default.