### PR TITLE
DM-50570: Fix trailed source filter

### DIFF
--- a/python/lsst/ap/association/filterDiaSourceCatalog.py
+++ b/python/lsst/ap/association/filterDiaSourceCatalog.py
@@ -47,6 +47,13 @@ class FilterDiaSourceCatalogConnections(
         dimensions=("instrument", "visit", "detector"),
     )
 
+    diffImVisitInfo = connTypes.Input(
+        doc="VisitInfo of diffIm.",
+        name="{fakesType}{coaddName}Diff_differenceExp.visitInfo",
+        storageClass="VisitInfo",
+        dimensions=("instrument", "visit", "detector"),
+    )
+
     filteredDiaSourceCat = connTypes.Output(
         doc="Output catalog of DiaSources after filtering.",
         name="{fakesType}{coaddName}Diff_candidateDiaSrc",
@@ -59,13 +66,6 @@ class FilterDiaSourceCatalogConnections(
         name="{fakesType}{coaddName}Diff_rejectedDiaSrc",
         storageClass="SourceCatalog",
         dimensions={"instrument", "visit", "detector"},
-    )
-
-    diffImVisitInfo = connTypes.Input(
-        doc="VisitInfo of diffIm.",
-        name="{fakesType}{coaddName}Diff_differenceExp.visitInfo",
-        storageClass="VisitInfo",
-        dimensions=("instrument", "visit", "detector"),
     )
 
     longTrailedSources = connTypes.Output(


### PR DESCRIPTION
The trailed source length is stored in units of pixels, but the threshold for filtering out long trailed sources is in arcseconds. Add a simple calculation to convert the trail length to the correct units before applying the filter.