### PR TITLE
DM-50035: Prompt Processing APDB download metric misses failed operations

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -585,10 +585,12 @@ class DiaPipelineTask(pipeBase.PipelineTask):
             forcedSourceHistoryThreshold = 0
 
         # Write results to Alert Production Database (APDB)
-        self.writeToApdb(updatedDiaObjects, assocResults.associatedDiaSources, diaForcedSources)
-        self.metadata["writeToApdbDuration"] = duration_from_timeMethod(self.metadata, "writeToApdb")
-        # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
-        self.log.verbose("writeToApdb: Took %.4f seconds", self.metadata["writeToApdbDuration"])
+        try:
+            self.writeToApdb(updatedDiaObjects, assocResults.associatedDiaSources, diaForcedSources)
+        finally:
+            self.metadata["writeToApdbDuration"] = duration_from_timeMethod(self.metadata, "writeToApdb")
+            # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
+            self.log.verbose("writeToApdb: Took %.4f seconds", self.metadata["writeToApdbDuration"])
 
         # Package alerts
         if self.config.doPackageAlerts:

--- a/python/lsst/ap/association/loadDiaCatalogs.py
+++ b/python/lsst/ap/association/loadDiaCatalogs.py
@@ -152,21 +152,29 @@ class LoadDiaCatalogsTask(pipeBase.PipelineTask):
         schema = readSchemaFromApdb(self.apdb)
 
         # This is the first database query.
-        diaObjects = self.loadDiaObjects(region, schema)
-        self.metadata["loadDiaObjectsDuration"] = duration_from_timeMethod(self.metadata, "loadDiaObjects")
+        try:
+            diaObjects = self.loadDiaObjects(region, schema)
+        finally:
+            self.metadata["loadDiaObjectsDuration"] = duration_from_timeMethod(
+                self.metadata, "loadDiaObjects")
 
         # Load diaSources and forced sources up to the time of the exposure
         # The timespan may include significant padding, so use the midpoint to
         #  avoid missing valid recent diaSources.
         visitTime = getMidpointFromTimespan(regionTime.timespan)
 
-        diaSources = self.loadDiaSources(diaObjects, region, visitTime, schema)
-        self.metadata["loadDiaSourcesDuration"] = duration_from_timeMethod(self.metadata, "loadDiaSources")
+        try:
+            diaSources = self.loadDiaSources(diaObjects, region, visitTime, schema)
+        finally:
+            self.metadata["loadDiaSourcesDuration"] = duration_from_timeMethod(
+                self.metadata, "loadDiaSources")
 
         if self.config.doLoadForcedSources:
-            diaForcedSources = self.loadDiaForcedSources(diaObjects, region, visitTime, schema)
-            self.metadata["loadDiaForcedSourcesDuration"] = duration_from_timeMethod(self.metadata,
-                                                                                     "loadDiaForcedSources")
+            try:
+                diaForcedSources = self.loadDiaForcedSources(diaObjects, region, visitTime, schema)
+            finally:
+                self.metadata["loadDiaForcedSourcesDuration"] = duration_from_timeMethod(
+                    self.metadata, "loadDiaForcedSources")
         else:
             diaForcedSources = pd.DataFrame(columns=["diaObjectId", "diaForcedSourceId"])
             self.metadata["loadDiaForcedSourcesDuration"] = -1

--- a/python/lsst/ap/association/loadDiaCatalogs.py
+++ b/python/lsst/ap/association/loadDiaCatalogs.py
@@ -157,6 +157,7 @@ class LoadDiaCatalogsTask(pipeBase.PipelineTask):
         finally:
             self.metadata["loadDiaObjectsDuration"] = duration_from_timeMethod(
                 self.metadata, "loadDiaObjects")
+            self.log.verbose("DiaObjects: Took %.4f seconds", self.metadata["loadDiaObjectsDuration"])
 
         # Load diaSources and forced sources up to the time of the exposure
         # The timespan may include significant padding, so use the midpoint to
@@ -168,6 +169,7 @@ class LoadDiaCatalogsTask(pipeBase.PipelineTask):
         finally:
             self.metadata["loadDiaSourcesDuration"] = duration_from_timeMethod(
                 self.metadata, "loadDiaSources")
+            self.log.verbose("DiaSources: Took %.4f seconds", self.metadata["loadDiaSourcesDuration"])
 
         if self.config.doLoadForcedSources:
             try:
@@ -175,6 +177,8 @@ class LoadDiaCatalogsTask(pipeBase.PipelineTask):
             finally:
                 self.metadata["loadDiaForcedSourcesDuration"] = duration_from_timeMethod(
                     self.metadata, "loadDiaForcedSources")
+                self.log.verbose("DiaForcedSources: Took %.4f seconds",
+                                 self.metadata["loadDiaForcedSourcesDuration"])
         else:
             diaForcedSources = pd.DataFrame(columns=["diaObjectId", "diaForcedSourceId"])
             self.metadata["loadDiaForcedSourcesDuration"] = -1

--- a/python/lsst/ap/association/packageAlerts.py
+++ b/python/lsst/ap/association/packageAlerts.py
@@ -399,38 +399,42 @@ class PackageAlertsTask(pipeBase.Task):
         # Serialize and send alerts with the producer timestamp.
         total_alerts = 0
         produce_start_timestamp = time.time()
-        for alert in alerts:
-            alertBytes = self._serializeAlert(alert, schema=self.alertSchema.definition, schema_id=schema_id)
-            try:
-                timestamp = time.time()*1000  # Current time in milliseconds
-                headers = [("producer_timestamp", str(timestamp).encode('utf-8'))]
-                self.producer.produce(self.kafkaTopic, alertBytes, callback=self._delivery_callback,
-                                      headers=headers)
-                self.producer.flush()
-                total_alerts += 1
+        try:
+            for alert in alerts:
+                alertBytes = self._serializeAlert(alert,
+                                                  schema=self.alertSchema.definition, schema_id=schema_id)
+                try:
+                    timestamp = time.time()*1000  # Current time in milliseconds
+                    headers = [("producer_timestamp", str(timestamp).encode('utf-8'))]
+                    self.producer.produce(self.kafkaTopic, alertBytes, callback=self._delivery_callback,
+                                          headers=headers)
+                    self.producer.flush()
+                    total_alerts += 1
 
-            except KafkaException as e:
-                self.log.warning('Kafka error: {}, message was {} bytes'.format(e, sys.getsizeof(alertBytes)))
+                except KafkaException as e:
+                    self.log.warning('Kafka error: %s, message was %s bytes',
+                                     e, sys.getsizeof(alertBytes))
 
-                if self.config.doWriteFailedAlerts:
-                    with open(os.path.join(self.config.alertWriteLocation,
-                                           f"{visit}_{detector}_{alert['alertId']}.avro"), "wb") as f:
-                        f.write(alertBytes)
+                    if self.config.doWriteFailedAlerts:
+                        with open(os.path.join(self.config.alertWriteLocation,
+                                               f"{visit}_{detector}_{alert['alertId']}.avro"), "wb") as f:
+                            f.write(alertBytes)
 
-        self.producer.flush()
-        produce_end_timestamp = time.time()  # Current time in seconds
-        total_time = produce_end_timestamp - (midpoint_unix + exposure_time/2.0)
-        self.metadata['visit_midpoint'] = midpoint_unix
-        self.metadata['produce_end_timestamp'] = produce_end_timestamp
-        self.metadata['produce_start_timestamp'] = produce_start_timestamp
-        self.metadata['alert_timing_since_shutter_close'] = total_time
-        self.metadata['total_alerts'] = total_alerts
-        # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
-        self.log.verbose("Producing alerts: Took %.4f seconds",
-                         produce_end_timestamp - produce_start_timestamp)
+            self.producer.flush()
+        finally:
+            produce_end_timestamp = time.time()  # Current time in seconds
+            total_time = produce_end_timestamp - (midpoint_unix + exposure_time/2.0)
+            self.metadata['visit_midpoint'] = midpoint_unix
+            self.metadata['produce_end_timestamp'] = produce_end_timestamp
+            self.metadata['produce_start_timestamp'] = produce_start_timestamp
+            self.metadata['alert_timing_since_shutter_close'] = total_time
+            self.metadata['total_alerts'] = total_alerts
+            # A single log message is easier for Loki to parse than timeMethod's start+end pairs.
+            self.log.verbose("Producing alerts: Took %.4f seconds",
+                             produce_end_timestamp - produce_start_timestamp)
 
-        self.log.info(f"Total time since shutter close to produce alerts for"
-                      f" visit {visit} detector {detector}: {total_time} seconds")
+            self.log.info(f"Total time since shutter close to produce alerts for"
+                          f" visit {visit} detector {detector}: {total_time} seconds")
 
     def createCcdDataCutout(self, image, skyCenter, pixelCenter, extent, photoCalib, srcId, averagePsf=None):
         """Grab an image as a cutout and return a calibrated CCDData image.


### PR DESCRIPTION
This PR modifies the `ap_association` timing code to run whether the timed operation succeeded or raised, then adds Loki-friendly logs to `LoadDiaCatalogsTask`.