### PR TITLE
Revert DM-51228 - perform forced photometry on template

### DIFF
--- a/data/DiaSource.yaml
+++ b/data/DiaSource.yaml
@@ -209,21 +209,8 @@ funcs:
             - base_LocalPhotoCalib
     # snapDiffFlux not implemented and likely dropped due to no snaps.
     # snapDiffFluxErr not implemented and likely dropped due to no snaps.
-    
-    # these will be renamed to templateFlux/templateFluxErr (RFC-1093)
-    # on DM-50837
-    fpBkgd:
-        functor: LocalNanojansky
-        args:
-            - ip_diffim_forced_template_PsfFlux_instFlux
-            - ip_diffim_forced_template_PsfFlux_instFluxErr
-            - base_LocalPhotoCalib
-    fpBkgdErr:
-        functor: LocalNanojanskyErr
-        args:
-            - ip_diffim_forced_template_PsfFlux_instFlux
-            - ip_diffim_forced_template_PsfFlux_instFluxErr
-            - base_LocalPhotoCalib
+    # fpBkgd not measured yet. DM-
+    # fpBkgdErr not measured yet. DM-
 
     # These values below work but need a new functor for converting pixel^2
     # units to arcsec^2 DM-


### PR DESCRIPTION
This reverts commit 36860c3005f5ee111192f4cb9196888e3aa3e103, reversing changes made to b2c191e6fd8eca712aff58d3bf7c0260a7bd0e9d.