### PR TITLE
DM-50988: Flag DIASources consistent with glints from rotating space junk

### DIFF
--- a/data/DiaSource.yaml
+++ b/data/DiaSource.yaml
@@ -269,3 +269,6 @@ funcs:
     reliability:
         functor: Column
         args: reliability
+    trailed_glint:
+        functor: Column
+        args: trailed_glint


### PR DESCRIPTION
Thie PR adds the new trailed_glint column to the DiaSource.yaml data model so ci_imsim doesn't fall over.

n.b. DM-51228 had the opposite failure, where the new column was here but not in sdm_schemas 😄 