### PR TITLE
DM-51885: Filter glint trails not associated with existing DIAObjects

### DIFF
--- a/python/lsst/ap/association/diaPipe.py
+++ b/python/lsst/ap/association/diaPipe.py
@@ -367,7 +367,8 @@ class DiaPipelineConfig(pipeBase.PipelineTaskConfig,
                  "pixelFlags_interpolatedCenter",
                  "pixelFlags_saturatedCenter",
                  "pixelFlags_suspectCenter",
-                 "pixelFlags_streakCenter"),
+                 "pixelFlags_streakCenter",
+                 "glint_trail"),
         doc="If `filterUnAssociatedSources` is set, exclude diaSources with "
         "these flags set before creating new diaObjects.",
     )


### PR DESCRIPTION
This PR adds `glint_trail` to the list of flags used in filtering out `unAssociatedSources`.