### PR TITLE
DM-52464: Fix Functor for trailedFluxErr

### DIFF
--- a/data/DiaSource.yaml
+++ b/data/DiaSource.yaml
@@ -96,9 +96,8 @@ funcs:
             - ext_trailedSources_Naive_flux
             - ext_trailedSources_Naive_fluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     trailFluxErr:
-        functor: LocalNanojansky
+        functor: LocalNanojanskyErr
         args:
             - ext_trailedSources_Naive_flux
             - ext_trailedSources_Naive_fluxErr


### PR DESCRIPTION
trailedFluxErr functor had the incorrect type and was then using the value for trailedFlux instead of trailedFluxErr.