### PR TITLE
DM-52455: Revert filtering sources with CR mask set in their footprint

### DIFF
--- a/python/lsst/ap/association/filterDiaSourceCatalog.py
+++ b/python/lsst/ap/association/filterDiaSourceCatalog.py
@@ -108,7 +108,6 @@ class FilterDiaSourceCatalogConfig(
     badFlagList = pexConfig.ListField(
         dtype=str,
         default=[
-            "base_PixelFlags_flag_cr",  # Temporarily filter all diaSources contaminated by CRs.
             "base_PixelFlags_flag_crCenter",
             "base_PixelFlags_flag_high_varianceCenterAll"
         ],

--- a/tests/test_filterDiaSourceCatalog.py
+++ b/tests/test_filterDiaSourceCatalog.py
@@ -58,8 +58,6 @@ class TestFilterDiaSourceCatalogTask(unittest.TestCase):
         schema.addField("sky_source", type="Flag", doc="Sky objects.")
         schema.addField("base_PixelFlags_flag_crCenter", type="Flag", doc="A cosmic ray was detected "
                         "and interpolated in this object's center.")
-        schema.addField("base_PixelFlags_flag_cr", type="Flag", doc="A cosmic ray was detected "
-                        "and interpolated anywhere in this objects footprint.")
         schema.addField("base_PixelFlags_flag_high_varianceCenterAll", type="Flag", doc="The object was "
                         "detected in a region with exceptionally high template variance.")
         schema.addField("fakeBadFlag", type="Flag", doc="A fake flag to test a badFlagList longer "


### PR DESCRIPTION
Reverts changes on DM-52434 now that CRs are properly masked in calibrateImage